### PR TITLE
Shut down periodic reader when evicting metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ CACHE_CMD ?= k8s-cache
 CACHE_MAIN_GO_FILE ?= cmd/$(CACHE_CMD)/main.go
 
 GOOS ?= linux
-GOARCH ?= amd64
+GOARCH ?= arm64
 
 # todo: upload to a grafana artifact
 PROTOC_IMAGE = docker.io/mariomac/protoc-go:latest
@@ -19,7 +19,7 @@ TEST_OUTPUT ?= ./testoutput
 
 IMG_REGISTRY ?= docker.io
 # Set your registry username. CI will set 'grafana' but you mustn't use it for manual pushing.
-IMG_ORG ?=
+IMG_ORG ?= oodle
 IMG_NAME ?= beyla
 # Container image creation creation
 VERSION ?= dev
@@ -256,6 +256,12 @@ image-build-push:
 	@echo "### Building and pushing the auto-instrumenter image"
 	$(call check_defined, IMG_ORG, Your Docker repository user name)
 	$(OCI_BIN) buildx build --push --platform linux/amd64,linux/arm64 -t ${IMG} .
+
+.PHONY: image-build
+image-build:
+	@echo "### Building and pushing the auto-instrumenter image"
+	$(call check_defined, IMG_ORG, Your Docker repository user name)
+	$(OCI_BIN) buildx build --platform linux/amd64,linux/arm64 -t ${IMG} .
 
 .PHONY: generator-image-build
 generator-image-build:

--- a/pkg/export/otel/metric/periodic_reader.go
+++ b/pkg/export/otel/metric/periodic_reader.go
@@ -169,6 +169,12 @@ func (r *PeriodicReader) run(ctx context.Context, interval time.Duration) {
 		case <-ticker.C:
 			err := r.collectAndExport(ctx)
 			if err != nil {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
 				otel.Handle(err)
 			}
 		case errCh := <-r.flushCh:
@@ -333,11 +339,6 @@ func (r *PeriodicReader) Shutdown(ctx context.Context) error {
 				err = r.export(ctx, m)
 			}
 			r.rmPool.Put(m)
-		}
-
-		sErr := r.exporter.Shutdown(ctx)
-		if err == nil || errors.Is(err, ErrReaderShutdown) {
-			err = sErr
 		}
 
 		r.mu.Lock()

--- a/pkg/export/otel/metrics.go
+++ b/pkg/export/otel/metrics.go
@@ -354,6 +354,12 @@ func newMetricsReporter(
 			llog.Debug("evicting metrics reporter from cache")
 			v.value.cleanupAllMetricsInstances()
 			go func() {
+				defer func() {
+					if err := v.value.provider.Shutdown(ctx); err != nil {
+						llog.Warn("error shutting down metrics provider", "error", err)
+					}
+				}()
+			
 				if err := v.value.provider.ForceFlush(ctx); err != nil {
 					llog.Warn("error flushing evicted metrics provider", "error", err)
 				}

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -177,6 +177,12 @@ func newProcMetricsExporter(
 			llog.Debug("evicting metrics reporter from cache")
 			v.value.cleanupAllMetricsInstances()
 			go func() {
+				defer func() {
+					if err := v.value.provider.Shutdown(ctx); err != nil {
+						llog.Warn("error shutting down metrics provider", "error", err)
+					}
+				}()
+
 				if err := v.value.provider.ForceFlush(ctx); err != nil {
 					llog.Warn("error flushing evicted metrics provider", "error", err)
 				}

--- a/pkg/internal/infraolly/process/collect.go
+++ b/pkg/internal/infraolly/process/collect.go
@@ -116,7 +116,8 @@ func (ps *Collector) Collect(pids map[int32]*svc.Attrs) ([]*Status, []int32) {
 	// remove processes from cache that haven't been collected in this iteration
 	// (this means they already disappeared so there is no need for caching)
 	for ps.cache.Len() > len(results) {
-		ps.cache.RemoveOldest()
+		oldestKey, _, _ := ps.cache.RemoveOldest()
+		removed = append(removed, oldestKey)
 	}
 
 	return results, removed

--- a/pkg/internal/infraolly/process/snapshot.go
+++ b/pkg/internal/infraolly/process/snapshot.go
@@ -114,13 +114,12 @@ func getLinuxProcess(cachedCopy *linuxProcess, procFSRoot string, pid int32, pri
 	}
 
 	// Reusing information from the last snapshot for the same process
-	// If the name or the PPID changed from the cachedCopy, we'll consider this sample is just
+	// If the name, PPID or start time changed from the cachedCopy, we'll consider this sample is just
 	// a new process that shares the PID with an old one.
-	// if a process with the same Command but different CommandLine or User name
-	// occupies the same PID, the cache won't refresh the CommandLine and Username.
 	if cachedCopy == nil ||
 		currentStats.command != cachedCopy.stats.command ||
-		currentStats.ppid != cachedCopy.stats.ppid {
+		currentStats.ppid != cachedCopy.stats.ppid ||
+		currentStats.startTime != cachedCopy.stats.startTime {
 
 		gops, err = process.NewProcess(pid)
 		if err != nil {
@@ -240,6 +239,7 @@ type procStats struct {
 	vmRSS      int64
 	vmSize     int64
 	cpu        CPUInfo
+	startTime  int64 // Add start time to track process creation time
 }
 
 // /proc/<pid>/stat standard field indices according to: http://man7.org/linux/man-pages/man5/proc.5.html
@@ -254,6 +254,7 @@ const (
 	statNumThreads = 17
 	statVsize      = 20
 	statRss        = 21
+	statStartTime  = 19
 )
 
 // readProcStat will gather information about the pid from /proc/<pid>/stat file.
@@ -298,6 +299,13 @@ func parseProcStat(content string) (procStats, error) {
 		return stats, errors.Wrapf(err, "for stats: %s", content)
 	}
 	stats.ppid = int32(ppid)
+
+	// Start time
+	startTime, err := strconv.ParseInt(fields[statStartTime], 10, 64)
+	if err != nil {
+		return stats, errors.Wrapf(err, "for stats: %s", content)
+	}
+	stats.startTime = startTime
 
 	// User time
 	utime, err := strconv.ParseInt(fields[statUtime], 10, 64)


### PR DESCRIPTION
If not shutdown, goroutines of periodic reader can get leaked