### PR TITLE
Add start time as a label

### DIFF
--- a/pkg/export/attributes/names/attrs.go
+++ b/pkg/export/attributes/names/attrs.go
@@ -123,6 +123,7 @@ const (
 	ProcCommandArgs = Name(semconv.ProcessCommandArgsKey)
 	ProcExecName    = Name(semconv.ProcessExecutableNameKey)
 	ProcExecPath    = Name(semconv.ProcessExecutablePathKey)
+	ProcStartTime   = Name(attribute.Key("process.start_time"))
 )
 
 // other beyla-specific attributes

--- a/pkg/export/otel/metrics_proc.go
+++ b/pkg/export/otel/metrics_proc.go
@@ -210,6 +210,7 @@ func getProcessResourceAttrs(hostID string, procID *process.ID) []attribute.KeyV
 		attr2.ProcCommandArgs.OTEL().StringSlice(procID.CommandArgs),
 		attr2.ProcExecName.OTEL().String(procID.ExecName),
 		attr2.ProcExecPath.OTEL().String(procID.ExecPath),
+		attr2.ProcStartTime.OTEL().String(strconv.Itoa(int(procID.StartTime))),
 	)
 }
 

--- a/pkg/internal/infraolly/process/harvest.go
+++ b/pkg/internal/infraolly/process/harvest.go
@@ -125,6 +125,7 @@ func (ps *Harvester) populateStaticData(status *Status, process *linuxProcess) e
 	status.ID.ExecName = process.execName
 
 	status.ID.ProcessID = process.Pid()
+	status.ID.StartTime = process.stats.startTime
 
 	var err error
 	if status.ID.User, err = process.Username(); err != nil {

--- a/pkg/internal/infraolly/process/status.go
+++ b/pkg/internal/infraolly/process/status.go
@@ -33,6 +33,7 @@ type ID struct {
 	CommandLine     string
 	ExecName        string
 	ExecPath        string
+	StartTime       int64
 }
 
 func (i *ID) GetUID() svc.UID {


### PR DESCRIPTION
PID is not enough to uniquely identify a process.

Add start time as a process metric label