### PR TITLE
Add PID Whitelister

### DIFF
--- a/pkg/clock/fake.go
+++ b/pkg/clock/fake.go
@@ -1,0 +1,49 @@
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+type FakeClock struct {
+	sync.Mutex
+	currentTime time.Time
+}
+
+var _ Clock = (*FakeClock)(nil)
+
+func NewFakeClock() *FakeClock {
+	return &FakeClock{
+		currentTime: time.Now(),
+	}
+}
+
+func (f *FakeClock) Now() time.Time {
+	f.Lock()
+	defer f.Unlock()
+	return f.currentTime
+}
+
+func (f *FakeClock) SetTime(t time.Time) {
+	f.Lock()
+	defer f.Unlock()
+	f.currentTime = t
+}
+
+func (f *FakeClock) Advance(d time.Duration) {
+	f.Lock()
+	defer f.Unlock()
+	f.currentTime = f.currentTime.Add(d)
+}
+
+func (f *FakeClock) Since(t time.Time) time.Duration {
+	f.Lock()
+	defer f.Unlock()
+	return f.currentTime.Sub(t)
+}
+
+func (f *FakeClock) Sleep(d time.Duration) {
+	f.Lock()
+	defer f.Unlock()
+	f.currentTime = f.currentTime.Add(d)
+}

--- a/pkg/clock/interface.go
+++ b/pkg/clock/interface.go
@@ -1,0 +1,13 @@
+package clock
+
+import "time"
+
+// Clock is an interface for getting the current time.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+	// Since returns the time elapsed since the given time.
+	Since(t time.Time) time.Duration
+	// Sleep pauses the current goroutine for at least the duration d.
+	Sleep(d time.Duration)
+}

--- a/pkg/clock/real.go
+++ b/pkg/clock/real.go
@@ -1,0 +1,26 @@
+package clock
+
+import (
+	"time"
+)
+
+type realClock struct {
+}
+
+var _ Clock = (*realClock)(nil)
+
+func NewRealClock() Clock {
+	return &realClock{}
+}
+
+func (r *realClock) Now() time.Time {
+	return time.Now()
+}
+
+func (r *realClock) Since(t time.Time) time.Duration {
+	return time.Since(t)
+}
+
+func (r *realClock) Sleep(d time.Duration) {
+	time.Sleep(d)
+}

--- a/pkg/export/otel/traces.go
+++ b/pkg/export/otel/traces.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	expirable2 "github.com/hashicorp/golang-lru/v2/expirable"
 	"github.com/mariomac/pipes/pipe"
@@ -665,7 +666,7 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 			request.ServerPort(span.HostPort),
 			span.DBSystemName(), // We can distinguish in the future for MySQL, Postgres etc
 		}
-		if _, ok := optionalAttrs[attr.DBQueryText]; ok {
+		if _, ok := optionalAttrs[attr.DBQueryText]; ok && utf8.ValidString(span.Statement) {
 			attrs = append(attrs, request.DBQueryText(span.Statement))
 		}
 		operation := span.Method
@@ -699,8 +700,11 @@ func traceAttributes(span *request.Span, optionalAttrs map[attr.Name]struct{}) [
 			request.ServerPort(span.HostPort),
 			semconv.MessagingSystemKafka,
 			semconv.MessagingDestinationName(span.Path),
-			semconv.MessagingClientID(span.Statement),
 			operation,
+		}
+
+		if utf8.ValidString(span.Statement) {
+			attrs = append(attrs, semconv.MessagingClientID(span.Statement))
 		}
 	}
 

--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -3,6 +3,7 @@ package prom
 import (
 	"context"
 	"fmt"
+	"github.com/grafana/beyla/v2/pkg/export/whitelister"
 	"runtime"
 	"slices"
 	"strconv"
@@ -227,7 +228,8 @@ type metricsReporter struct {
 	kubeEnabled bool
 	hostID      string
 
-	serviceCache *expirable.LRU[svc.UID, svc.Attrs]
+	serviceCache   *expirable.LRU[svc.UID, svc.Attrs]
+	pidWhitelister *whitelister.PIDWhitelister
 }
 
 func PrometheusEndpoint(
@@ -348,6 +350,7 @@ func newReporter(
 		attrHTTPClientRequestSize: attrHTTPClientRequestSize,
 		attrGPUKernelCalls:        attrGPUKernelLaunchCalls,
 		attrGPUMemoryAllocs:       attrGPUMemoryAllocations,
+		pidWhitelister:            whitelister.GetPIDWhitelister(),
 		beylaInfo: NewExpirer[prometheus.Gauge](prometheus.NewGaugeVec(prometheus.GaugeOpts{
 			Name: BeylaBuildInfo,
 			Help: "A metric with a constant '1' value labeled by version, revision, branch, " +
@@ -702,6 +705,11 @@ func (r *metricsReporter) observe(span *request.Span) {
 	if r.otelSpanFiltered(span) {
 		return
 	}
+
+	if !r.pidWhitelister.IsWhitelisted(span.Pid) {
+		return
+	}
+
 	t := span.Timings()
 	r.beylaInfo.WithLabelValues(span.Service.SDKLanguage.String()).metric.Set(1.0)
 	if r.cfg.SpanMetricsEnabled() || r.cfg.ServiceGraphMetricsEnabled() {

--- a/pkg/export/prom/prom_proc.go
+++ b/pkg/export/prom/prom_proc.go
@@ -12,9 +12,11 @@ import (
 	attr2 "github.com/grafana/beyla/v2/pkg/export/attributes/names"
 	"github.com/grafana/beyla/v2/pkg/export/expire"
 	"github.com/grafana/beyla/v2/pkg/export/otel"
+	"github.com/grafana/beyla/v2/pkg/export/whitelister"
 	"github.com/grafana/beyla/v2/pkg/internal/connector"
 	"github.com/grafana/beyla/v2/pkg/internal/infraolly/process"
 	"github.com/grafana/beyla/v2/pkg/internal/pipe/global"
+	"github.com/grafana/beyla/v2/pkg/internal/request"
 )
 
 // injectable function reference for testing
@@ -90,6 +92,8 @@ type procMetricsReporter struct {
 	// the "*.io.direction" attributes
 	diskObserver func(*process.Status)
 	netObserver  func(*process.Status)
+
+	pidWhitelister *whitelister.PIDWhitelister
 }
 
 func newProcReporter(
@@ -157,6 +161,7 @@ func newProcReporter(
 			Name: attributes.ProcessNetIO.Prom,
 			Help: "Network bytes transferred",
 		}, netLblNames).MetricVec, clock.Time, cfg.Metrics.TTL),
+		pidWhitelister: whitelister.GetPIDWhitelister(),
 	}
 
 	if cpuTimeHasState {
@@ -214,6 +219,16 @@ func (r *procMetricsReporter) collectMetrics(input <-chan []*process.Status) {
 }
 
 func (r *procMetricsReporter) observeMetric(proc *process.Status) {
+	if !r.pidWhitelister.IsWhitelisted(
+		// Use a combination to unique identify the process.
+		request.PidInfo{
+			HostPID:   uint32(proc.ID.ParentProcessID),
+			UserPID:   uint32(proc.ID.ProcessID),
+			Namespace: uint32(proc.ID.StartTime),
+		}) {
+		return
+	}
+
 	r.cpuTimeObserver(proc)
 	r.cpuUtilizationObserver(proc)
 	r.memory.WithLabelValues(labelValues(proc, r.memoryAttrs)...).

--- a/pkg/export/whitelister/pid_whitelister.go
+++ b/pkg/export/whitelister/pid_whitelister.go
@@ -1,0 +1,110 @@
+package whitelister
+
+import (
+	"sync"
+	"time"
+
+	"github.com/puzpuzpuz/xsync/v3"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/beyla/v2/pkg/clock"
+	"github.com/grafana/beyla/v2/pkg/flaggy"
+	"github.com/grafana/beyla/v2/pkg/internal/request"
+)
+
+var pidWhitelisterIgnorePIDDuration = flaggy.GetEnvDurationVar(
+	"PID_WHITELISTER_IGNORE_PID_DURATION",
+	"pid_whitelister_ignore_pid_duration",
+	"PID Whitelister will ignore a PID for this duration after it is first seen",
+	3*time.Minute,
+)
+
+var pidWhitelisterExpirePIDDuration = flaggy.GetEnvDurationVar(
+	"PID_WHITELISTER_EXPIRE_PID_DURATION",
+	"pid_whitelister_expire_pid_duration",
+	"PID Whitelister will expire a PID if not seen for this duration",
+	5*time.Minute,
+)
+
+var pidWhitelisterExpirePollingInterval = flaggy.GetEnvDurationVar(
+	"PID_WHITELISTER_EXPIRE_POLLING_INTERVAL",
+	"pid_whitelister_expire_polling_interval",
+	"PID Whitelister will poll for expired PIDs every this duration",
+	time.Minute,
+)
+
+type PIDWhitelisterStats struct {
+	FirstSeen time.Time
+	LastSeen  time.Time
+}
+
+type PIDWhitelister struct {
+	ignoreDuration time.Duration
+	expireDuration time.Duration
+	pids           *xsync.MapOf[request.PidInfo, *PIDWhitelisterStats]
+	eg             errgroup.Group
+	cl             clock.Clock
+}
+
+func newPIDWhitelister(cl clock.Clock) *PIDWhitelister {
+	return &PIDWhitelister{
+		ignoreDuration: *pidWhitelisterIgnorePIDDuration,
+		expireDuration: *pidWhitelisterExpirePIDDuration,
+		pids:           xsync.NewMapOf[request.PidInfo, *PIDWhitelisterStats](),
+		cl:             cl,
+	}
+}
+
+func (pw *PIDWhitelister) Start() {
+	pw.eg.Go(func() error {
+		ticker := time.NewTicker(*pidWhitelisterExpirePollingInterval)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-ticker.C:
+				pw.cleanupExpiredPIDs()
+			}
+		}
+	})
+}
+
+func (pidw *PIDWhitelister) cleanupExpiredPIDs() {
+	pidw.pids.Range(func(pid request.PidInfo, info *PIDWhitelisterStats) bool {
+		if pidw.cl.Since(info.LastSeen) > pidw.expireDuration {
+			pidw.pids.Delete(pid)
+		}
+		return true
+	})
+}
+
+func (pw *PIDWhitelister) IsWhitelisted(pid request.PidInfo) bool {
+	now := pw.cl.Now()
+
+	info, ok := pw.pids.LoadOrCompute(pid, func() *PIDWhitelisterStats {
+		return &PIDWhitelisterStats{
+			FirstSeen: now,
+			LastSeen:  now,
+		}
+	})
+
+	if !ok {
+		return false
+	}
+
+	info.LastSeen = now
+
+	return pw.cl.Since(info.FirstSeen) > pw.ignoreDuration
+}
+
+var pidWhitelister *PIDWhitelister
+var once sync.Once
+
+func GetPIDWhitelister() *PIDWhitelister {
+	once.Do(func() {
+		pidWhitelister = newPIDWhitelister(clock.NewRealClock())
+		pidWhitelister.Start()
+	})
+
+	return pidWhitelister
+}

--- a/pkg/export/whitelister/pid_whitelister_test.go
+++ b/pkg/export/whitelister/pid_whitelister_test.go
@@ -1,0 +1,298 @@
+package whitelister
+
+import (
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/grafana/beyla/v2/pkg/clock"
+	"github.com/grafana/beyla/v2/pkg/internal/request"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewPIDWhitelister(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	assert.NotNil(t, whitelister)
+	assert.Equal(t, *pidWhitelisterIgnorePIDDuration, whitelister.ignoreDuration)
+	assert.Equal(t, *pidWhitelisterExpirePIDDuration, whitelister.expireDuration)
+	assert.NotNil(t, whitelister.pids)
+	assert.Equal(t, fakeClock, whitelister.cl)
+}
+
+func TestPIDWhitelister_IsWhitelisted_FirstTime(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 12345}
+
+	// First time seeing the PID should return false (still in ignore period)
+	result := whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+
+	// Verify the PID was added to the map
+	info, exists := whitelister.pids.Load(pid)
+	assert.True(t, exists)
+	assert.Equal(t, fakeClock.Now(), info.FirstSeen)
+	assert.Equal(t, fakeClock.Now(), info.LastSeen)
+}
+
+func TestPIDWhitelister_IsWhitelisted_AfterIgnoreDuration(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 12345}
+
+	// First time seeing the PID
+	result := whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+
+	// Advance time past the ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration + time.Second)
+
+	// Now it should be whitelisted
+	result = whitelister.IsWhitelisted(pid)
+	assert.True(t, result)
+
+	// Verify LastSeen was updated
+	info, exists := whitelister.pids.Load(pid)
+	assert.True(t, exists)
+	assert.Equal(t, fakeClock.Now(), info.LastSeen)
+}
+
+func TestPIDWhitelister_IsWhitelisted_JustBeforeIgnoreDuration(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 12345}
+
+	// First time seeing the PID
+	result := whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+
+	// Advance time just before the ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration - time.Second)
+
+	// Should still not be whitelisted
+	result = whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+}
+
+func TestPIDWhitelister_IsWhitelisted_MultiplePIDs(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid1 := request.PidInfo{HostPID: 12345}
+	pid2 := request.PidInfo{HostPID: 67890}
+
+	// First time seeing both PIDs
+	assert.False(t, whitelister.IsWhitelisted(pid1))
+	assert.False(t, whitelister.IsWhitelisted(pid2))
+
+	// Advance time past ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration + time.Second)
+
+	// Both should now be whitelisted
+	assert.True(t, whitelister.IsWhitelisted(pid1))
+	assert.True(t, whitelister.IsWhitelisted(pid2))
+
+	// Verify both PIDs are in the map
+	_, exists1 := whitelister.pids.Load(pid1)
+	_, exists2 := whitelister.pids.Load(pid2)
+	assert.True(t, exists1)
+	assert.True(t, exists2)
+}
+
+func TestPIDWhitelister_IsWhitelisted_UpdateLastSeen(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 12345}
+
+	// First time seeing the PID
+	assert.False(t, whitelister.IsWhitelisted(pid))
+
+	// Advance time past ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration + time.Second)
+
+	// Now it should be whitelisted
+	assert.True(t, whitelister.IsWhitelisted(pid))
+
+	// Get the initial LastSeen
+	info, _ := whitelister.pids.Load(pid)
+	initialLastSeen := info.LastSeen
+
+	// Advance time and check again
+	fakeClock.Advance(time.Minute)
+	assert.True(t, whitelister.IsWhitelisted(pid))
+
+	// Verify LastSeen was updated
+	info, _ = whitelister.pids.Load(pid)
+	assert.True(t, info.LastSeen.After(initialLastSeen))
+}
+
+func TestPIDWhitelister_CleanupExpiredPIDs(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid1 := request.PidInfo{HostPID: 12345}
+	pid2 := request.PidInfo{HostPID: 67890}
+
+	// Add both PIDs
+	whitelister.IsWhitelisted(pid1)
+	whitelister.IsWhitelisted(pid2)
+
+	// Verify both are in the map
+	assert.Equal(t, 2, whitelister.pids.Size())
+
+	// Advance time past expire duration for pid1
+	fakeClock.Advance(*pidWhitelisterExpirePIDDuration + time.Second)
+
+	// Update pid2 to be recent
+	whitelister.IsWhitelisted(pid2)
+
+	// Clean up expired PIDs
+	whitelister.cleanupExpiredPIDs()
+
+	// pid1 should be removed, pid2 should remain
+	assert.Equal(t, 1, whitelister.pids.Size())
+
+	_, exists1 := whitelister.pids.Load(pid1)
+	_, exists2 := whitelister.pids.Load(pid2)
+	assert.False(t, exists1)
+	assert.True(t, exists2)
+}
+
+func TestPIDWhitelister_CleanupExpiredPIDs_NoExpired(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 12345}
+
+	// Add PID
+	whitelister.IsWhitelisted(pid)
+
+	// Verify it's in the map
+	assert.Equal(t, 1, whitelister.pids.Size())
+
+	// Advance time but not past expire duration
+	fakeClock.Advance(*pidWhitelisterExpirePIDDuration - time.Second)
+
+	// Clean up expired PIDs
+	whitelister.cleanupExpiredPIDs()
+
+	// PID should still be in the map
+	assert.Equal(t, 1, whitelister.pids.Size())
+
+	_, exists := whitelister.pids.Load(pid)
+	assert.True(t, exists)
+}
+
+func TestPIDWhitelister_Start(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	// Start the cleanup goroutine
+	whitelister.Start()
+
+	// Add a PID
+	pid := request.PidInfo{HostPID: 12345}
+	whitelister.IsWhitelisted(pid)
+
+	// Verify it's in the map
+	assert.Equal(t, 1, whitelister.pids.Size())
+
+	// Test that the cleanup goroutine is running by checking that
+	// the whitelister is properly initialized
+	assert.NotNil(t, whitelister.pids)
+	assert.NotNil(t, whitelister.cl)
+
+	// The actual cleanup functionality is tested in TestPIDWhitelister_CleanupExpiredPIDs
+	// This test just verifies that Start() doesn't panic and initializes properly
+}
+
+func TestGetPIDWhitelister_Singleton(t *testing.T) {
+	// Reset the singleton for testing
+	pidWhitelister = nil
+	once = sync.Once{}
+
+	// Get the whitelister twice
+	whitelister1 := GetPIDWhitelister()
+	whitelister2 := GetPIDWhitelister()
+
+	// Should be the same instance
+	assert.Equal(t, whitelister1, whitelister2)
+	assert.NotNil(t, whitelister1)
+}
+
+func TestPIDWhitelister_ConcurrentAccess(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	// Test concurrent access to IsWhitelisted
+	done := make(chan bool, 10)
+
+	for i := 0; i < 10; i++ {
+		go func(pid int) {
+			pidInfo := request.PidInfo{HostPID: uint32(pid)}
+			whitelister.IsWhitelisted(pidInfo)
+			done <- true
+		}(i)
+	}
+
+	// Wait for all goroutines to complete
+	for i := 0; i < 10; i++ {
+		<-done
+	}
+
+	// Should have 10 PIDs in the map
+	assert.Equal(t, 10, whitelister.pids.Size())
+}
+
+func TestPIDWhitelister_EdgeCase_ZeroPID(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: 0}
+
+	// Should handle zero PID
+	result := whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+
+	// Advance time past ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration + time.Second)
+
+	// Should now be whitelisted
+	result = whitelister.IsWhitelisted(pid)
+	assert.True(t, result)
+}
+
+func TestPIDWhitelister_EdgeCase_MaxPID(t *testing.T) {
+	fakeClock := clock.NewFakeClock()
+	whitelister := newPIDWhitelister(fakeClock)
+
+	pid := request.PidInfo{HostPID: ^uint32(0)} // Max uint32
+
+	// Should handle max PID
+	result := whitelister.IsWhitelisted(pid)
+	assert.False(t, result)
+
+	// Advance time past ignore duration
+	fakeClock.Advance(*pidWhitelisterIgnorePIDDuration + time.Second)
+
+	// Should now be whitelisted
+	result = whitelister.IsWhitelisted(pid)
+	assert.True(t, result)
+}
+
+func TestPIDWhitelister_Stats_Fields(t *testing.T) {
+	stats := &PIDWhitelisterStats{
+		FirstSeen: time.Now(),
+		LastSeen:  time.Now().Add(time.Minute),
+	}
+
+	assert.False(t, stats.FirstSeen.IsZero())
+	assert.False(t, stats.LastSeen.IsZero())
+	assert.True(t, stats.LastSeen.After(stats.FirstSeen))
+}

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -2,6 +2,7 @@ package request
 
 import (
 	"strings"
+	"unicode/utf8"
 
 	"go.opentelemetry.io/otel/attribute"
 
@@ -122,7 +123,7 @@ func SpanPeer(span *Span) string {
 }
 
 func HTTPClientHost(span *Span) string {
-	if strings.Index(span.Statement, SchemeHostSeparator) > 0 {
+	if utf8.ValidString(span.Statement) && strings.Index(span.Statement, SchemeHostSeparator) > 0 {
 		schemeHost := strings.Split(span.Statement, SchemeHostSeparator)
 		if schemeHost[1] != "" {
 			return schemeHost[1]
@@ -133,7 +134,7 @@ func HTTPClientHost(span *Span) string {
 }
 
 func HTTPScheme(span *Span) string {
-	if strings.Index(span.Statement, SchemeHostSeparator) > 0 {
+	if utf8.ValidString(span.Statement) && strings.Index(span.Statement, SchemeHostSeparator) > 0 {
 		schemeHost := strings.Split(span.Statement, SchemeHostSeparator)
 		return schemeHost[0]
 	}

--- a/pkg/internal/request/span.go
+++ b/pkg/internal/request/span.go
@@ -186,6 +186,11 @@ func (s *Span) InternalSignal() bool {
 type SpanAttributes map[string]string
 
 func spanAttributes(s *Span) SpanAttributes {
+	statement := s.Statement
+	if !utf8.ValidString(statement) {
+		statement = ""
+	}
+
 	switch s.Type {
 	case EventTypeHTTP:
 		return SpanAttributes{
@@ -228,14 +233,14 @@ func spanAttributes(s *Span) SpanAttributes {
 			"serverPort": strconv.Itoa(s.HostPort),
 			"operation":  s.Method,
 			"table":      s.Path,
-			"statement":  s.Statement,
+			"statement":  statement,
 		}
 	case EventTypeRedisServer:
 		return SpanAttributes{
 			"serverAddr": SpanHost(s),
 			"serverPort": strconv.Itoa(s.HostPort),
 			"operation":  s.Method,
-			"statement":  s.Statement,
+			"statement":  statement,
 			"query":      s.Path,
 		}
 	case EventTypeKafkaServer:
@@ -553,6 +558,10 @@ func (s *Span) DBSystemName() attribute.KeyValue {
 }
 
 func (s *Span) HasOriginalHost() bool {
+	if !utf8.ValidString(s.Statement) {
+		return false
+	}
+
 	schemeHost := strings.Split(s.Statement, SchemeHostSeparator)
 	return len(schemeHost) > 1 && schemeHost[1] != ""
 }

--- a/pkg/interner/string.go
+++ b/pkg/interner/string.go
@@ -1,7 +1,6 @@
 package intern
 
 import (
-	"github.com/grafana/beyla/v2/pkg/flaggy"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -9,6 +8,8 @@ import (
 
 	"github.com/puzpuzpuz/xsync/v3"
 	"golang.org/x/sync/errgroup"
+
+	"github.com/grafana/beyla/v2/pkg/flaggy"
 )
 
 var defaultStringInternerResetInterval = flaggy.GetEnvDurationVar(

--- a/vendor/github.com/puzpuzpuz/xsync/v3/.gitignore
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/.gitignore
@@ -1,0 +1,15 @@
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/

--- a/vendor/github.com/puzpuzpuz/xsync/v3/BENCHMARKS.md
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/BENCHMARKS.md
@@ -1,0 +1,133 @@
+# xsync benchmarks
+
+If you're interested in `MapOf` comparison with some of the popular concurrent hash maps written in Go, check [this](https://github.com/cornelk/hashmap/pull/70) and [this](https://github.com/alphadose/haxmap/pull/22) PRs.
+
+The below results were obtained for xsync v2.3.1 on a c6g.metal EC2 instance (64 CPU, 128GB RAM) running Linux and Go 1.19.3. I'd like to thank [@felixge](https://github.com/felixge) who kindly ran the benchmarks.
+
+The following commands were used to run the benchmarks:
+```bash
+$ go test -run='^$' -cpu=1,2,4,8,16,32,64 -bench . -count=30 -timeout=0 | tee bench.txt
+$ benchstat bench.txt | tee benchstat.txt
+```
+
+The below sections contain some of the results. Refer to [this gist](https://gist.github.com/puzpuzpuz/e62e38e06feadecfdc823c0f941ece0b) for the complete output.
+
+Please note that `MapOf` got a number of optimizations since v2.3.1, so the current result is likely to be different.
+
+### Counter vs. atomic int64
+
+```
+name                                            time/op
+Counter                                         27.3ns ± 1%
+Counter-2                                       27.2ns ±11%
+Counter-4                                       15.3ns ± 8%
+Counter-8                                       7.43ns ± 7%
+Counter-16                                      3.70ns ±10%
+Counter-32                                      1.77ns ± 3%
+Counter-64                                      0.96ns ±10%
+AtomicInt64                                     7.60ns ± 0%
+AtomicInt64-2                                   12.6ns ±13%
+AtomicInt64-4                                   13.5ns ±14%
+AtomicInt64-8                                   12.7ns ± 9%
+AtomicInt64-16                                  12.8ns ± 8%
+AtomicInt64-32                                  13.0ns ± 6%
+AtomicInt64-64                                  12.9ns ± 7%
+```
+
+Here `time/op` stands for average time spent on operation. If you divide `10^9` by the result in nanoseconds per operation, you'd get the throughput in operations per second. Thus, the ideal theoretical scalability of a concurrent data structure implies that the reported `time/op` decreases proportionally with the increased number of CPU cores. On the contrary, if the measured time per operation increases when run on more cores, it means performance degradation.
+
+### MapOf vs. sync.Map
+
+1,000 `[int, int]` entries with a warm-up, 100% Loads:
+```
+IntegerMapOf_WarmUp/reads=100%                  24.0ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-2                12.0ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-4                6.02ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-8                3.01ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-16               1.50ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-32               0.75ns ± 0%
+IntegerMapOf_WarmUp/reads=100%-64               0.38ns ± 0%
+IntegerMapStandard_WarmUp/reads=100%            55.3ns ± 0%
+IntegerMapStandard_WarmUp/reads=100%-2          27.6ns ± 0%
+IntegerMapStandard_WarmUp/reads=100%-4          16.1ns ± 3%
+IntegerMapStandard_WarmUp/reads=100%-8          8.35ns ± 7%
+IntegerMapStandard_WarmUp/reads=100%-16         4.24ns ± 7%
+IntegerMapStandard_WarmUp/reads=100%-32         2.18ns ± 6%
+IntegerMapStandard_WarmUp/reads=100%-64         1.11ns ± 3%
+```
+
+1,000 `[int, int]` entries with a warm-up, 99% Loads, 0.5% Stores, 0.5% Deletes:
+```
+IntegerMapOf_WarmUp/reads=99%                   31.0ns ± 0%
+IntegerMapOf_WarmUp/reads=99%-2                 16.4ns ± 1%
+IntegerMapOf_WarmUp/reads=99%-4                 8.42ns ± 0%
+IntegerMapOf_WarmUp/reads=99%-8                 4.41ns ± 0%
+IntegerMapOf_WarmUp/reads=99%-16                2.38ns ± 2%
+IntegerMapOf_WarmUp/reads=99%-32                1.37ns ± 4%
+IntegerMapOf_WarmUp/reads=99%-64                0.85ns ± 2%
+IntegerMapStandard_WarmUp/reads=99%              121ns ± 1%
+IntegerMapStandard_WarmUp/reads=99%-2            109ns ± 3%
+IntegerMapStandard_WarmUp/reads=99%-4            115ns ± 4%
+IntegerMapStandard_WarmUp/reads=99%-8            114ns ± 2%
+IntegerMapStandard_WarmUp/reads=99%-16           105ns ± 2%
+IntegerMapStandard_WarmUp/reads=99%-32          97.0ns ± 3%
+IntegerMapStandard_WarmUp/reads=99%-64          98.0ns ± 2%
+```
+
+1,000 `[int, int]` entries with a warm-up, 75% Loads, 12.5% Stores, 12.5% Deletes:
+```
+IntegerMapOf_WarmUp/reads=75%-reads             46.2ns ± 1%
+IntegerMapOf_WarmUp/reads=75%-reads-2           36.7ns ± 2%
+IntegerMapOf_WarmUp/reads=75%-reads-4           22.0ns ± 1%
+IntegerMapOf_WarmUp/reads=75%-reads-8           12.8ns ± 2%
+IntegerMapOf_WarmUp/reads=75%-reads-16          7.69ns ± 1%
+IntegerMapOf_WarmUp/reads=75%-reads-32          5.16ns ± 1%
+IntegerMapOf_WarmUp/reads=75%-reads-64          4.91ns ± 1%
+IntegerMapStandard_WarmUp/reads=75%-reads        156ns ± 0%
+IntegerMapStandard_WarmUp/reads=75%-reads-2      177ns ± 1%
+IntegerMapStandard_WarmUp/reads=75%-reads-4      197ns ± 1%
+IntegerMapStandard_WarmUp/reads=75%-reads-8      221ns ± 2%
+IntegerMapStandard_WarmUp/reads=75%-reads-16     242ns ± 1%
+IntegerMapStandard_WarmUp/reads=75%-reads-32     258ns ± 1%
+IntegerMapStandard_WarmUp/reads=75%-reads-64     264ns ± 1%
+```
+
+### MPMCQueue vs. Go channels
+
+Concurrent producers and consumers (1:1), queue/channel size 1,000, some work done by both producers and consumers:
+```
+QueueProdConsWork100                             252ns ± 0%
+QueueProdConsWork100-2                           206ns ± 5%
+QueueProdConsWork100-4                           136ns ±12%
+QueueProdConsWork100-8                           110ns ± 6%
+QueueProdConsWork100-16                          108ns ± 2%
+QueueProdConsWork100-32                          102ns ± 2%
+QueueProdConsWork100-64                          101ns ± 0%
+ChanProdConsWork100                              283ns ± 0%
+ChanProdConsWork100-2                            406ns ±21%
+ChanProdConsWork100-4                            549ns ± 7%
+ChanProdConsWork100-8                            754ns ± 7%
+ChanProdConsWork100-16                           828ns ± 7%
+ChanProdConsWork100-32                           810ns ± 8%
+ChanProdConsWork100-64                           832ns ± 4%
+```
+
+### RBMutex vs. sync.RWMutex
+
+The writer locks on each 100,000 iteration with some work in the critical section for both readers and the writer:
+```
+RBMutexWorkWrite100000                           146ns ± 0%
+RBMutexWorkWrite100000-2                        73.3ns ± 0%
+RBMutexWorkWrite100000-4                        36.7ns ± 0%
+RBMutexWorkWrite100000-8                        18.6ns ± 0%
+RBMutexWorkWrite100000-16                       9.83ns ± 3%
+RBMutexWorkWrite100000-32                       5.53ns ± 0%
+RBMutexWorkWrite100000-64                       4.04ns ± 3%
+RWMutexWorkWrite100000                           121ns ± 0%
+RWMutexWorkWrite100000-2                         128ns ± 1%
+RWMutexWorkWrite100000-4                         124ns ± 2%
+RWMutexWorkWrite100000-8                         101ns ± 1%
+RWMutexWorkWrite100000-16                       92.9ns ± 1%
+RWMutexWorkWrite100000-32                       89.9ns ± 1%
+RWMutexWorkWrite100000-64                       88.4ns ± 1%
+```

--- a/vendor/github.com/puzpuzpuz/xsync/v3/LICENSE
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/puzpuzpuz/xsync/v3/README.md
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/README.md
@@ -1,0 +1,195 @@
+[![GoDoc reference](https://img.shields.io/badge/godoc-reference-blue.svg)](https://pkg.go.dev/github.com/puzpuzpuz/xsync/v3)
+[![GoReport](https://goreportcard.com/badge/github.com/puzpuzpuz/xsync/v3)](https://goreportcard.com/report/github.com/puzpuzpuz/xsync/v3)
+[![codecov](https://codecov.io/gh/puzpuzpuz/xsync/branch/main/graph/badge.svg)](https://codecov.io/gh/puzpuzpuz/xsync)
+
+# xsync
+
+Concurrent data structures for Go. Aims to provide more scalable alternatives for some of the data structures from the standard `sync` package, but not only.
+
+Covered with tests following the approach described [here](https://puzpuzpuz.dev/testing-concurrent-code-for-fun-and-profit).
+
+## Benchmarks
+
+Benchmark results may be found [here](BENCHMARKS.md). I'd like to thank [@felixge](https://github.com/felixge) who kindly ran the benchmarks on a beefy multicore machine.
+
+Also, a non-scientific, unfair benchmark comparing Java's [j.u.c.ConcurrentHashMap](https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ConcurrentHashMap.html) and `xsync.MapOf` is available [here](https://puzpuzpuz.dev/concurrent-map-in-go-vs-java-yet-another-meaningless-benchmark).
+
+## Usage
+
+The latest xsync major version is v3, so `/v3` suffix should be used when importing the library:
+
+```go
+import (
+	"github.com/puzpuzpuz/xsync/v3"
+)
+```
+
+*Note for pre-v3 users*: v1 and v2 support is discontinued, so please upgrade to v3. While the API has some breaking changes, the migration should be trivial.
+
+### Counter
+
+A `Counter` is a striped `int64` counter inspired by the `j.u.c.a.LongAdder` class from the Java standard library.
+
+```go
+c := xsync.NewCounter()
+// increment and decrement the counter
+c.Inc()
+c.Dec()
+// read the current value
+v := c.Value()
+```
+
+Works better in comparison with a single atomically updated `int64` counter in high contention scenarios.
+
+### Map
+
+A `Map` is like a concurrent hash table-based map. It follows the interface of `sync.Map` with a number of valuable extensions like `Compute` or `Size`.
+
+```go
+m := xsync.NewMap()
+m.Store("foo", "bar")
+v, ok := m.Load("foo")
+s := m.Size()
+```
+
+`Map` uses a modified version of Cache-Line Hash Table (CLHT) data structure: https://github.com/LPD-EPFL/CLHT
+
+CLHT is built around the idea of organizing the hash table in cache-line-sized buckets, so that on all modern CPUs update operations complete with minimal cache-line transfer. Also, `Get` operations are obstruction-free and involve no writes to shared memory, hence no mutexes or any other sort of locks. Due to this design, in all considered scenarios `Map` outperforms `sync.Map`.
+
+One important difference with `sync.Map` is that only string keys are supported. That's because Golang standard library does not expose the built-in hash functions for `interface{}` values.
+
+`MapOf[K, V]` is an implementation with parametrized key and value types. While it's still a CLHT-inspired hash map, `MapOf`'s design is quite different from `Map`. As a result, less GC pressure and fewer atomic operations on reads.
+
+```go
+m := xsync.NewMapOf[string, string]()
+m.Store("foo", "bar")
+v, ok := m.Load("foo")
+```
+
+Apart from CLHT, `MapOf` borrows ideas from Java's `j.u.c.ConcurrentHashMap` (immutable K/V pair structs instead of atomic snapshots) and C++'s `absl::flat_hash_map` (meta memory and SWAR-based lookups). It also has more dense memory layout when compared with `Map`. Long story short, `MapOf` should be preferred over `Map` when possible.
+
+An important difference with `Map` is that `MapOf` supports arbitrary `comparable` key types:
+
+```go
+type Point struct {
+	x int32
+	y int32
+}
+m := NewMapOf[Point, int]()
+m.Store(Point{42, 42}, 42)
+v, ok := m.Load(point{42, 42})
+```
+
+Apart from `Range` method available for map iteration, there are also `ToPlainMap`/`ToPlainMapOf` utility functions to convert a `Map`/`MapOf` to a built-in Go's `map`:
+```go
+m := xsync.NewMapOf[int, int]()
+m.Store(42, 42)
+pm := xsync.ToPlainMapOf(m)
+```
+
+Both `Map` and `MapOf` use the built-in Golang's hash function which has DDOS protection. This means that each map instance gets its own seed number and the hash function uses that seed for hash code calculation. However, for smaller keys this hash function has some overhead. So, if you don't need DDOS protection, you may provide a custom hash function when creating a `MapOf`. For instance, Murmur3 finalizer does a decent job when it comes to integers:
+
+```go
+m := NewMapOfWithHasher[int, int](func(i int, _ uint64) uint64 {
+	h := uint64(i)
+	h = (h ^ (h >> 33)) * 0xff51afd7ed558ccd
+	h = (h ^ (h >> 33)) * 0xc4ceb9fe1a85ec53
+	return h ^ (h >> 33)
+})
+```
+
+When benchmarking concurrent maps, make sure to configure all of the competitors with the same hash function or, at least, take hash function performance into the consideration.
+
+### SPSCQueue
+
+A `SPSCQueue` is a bounded single-producer single-consumer concurrent queue. This means that not more than a single goroutine must be publishing items to the queue while not more than a single goroutine must be consuming those items.
+
+```go
+q := xsync.NewSPSCQueue(1024)
+// producer inserts an item into the queue
+// optimistic insertion attempt; doesn't block
+inserted := q.TryEnqueue("bar")
+// consumer obtains an item from the queue
+// optimistic obtain attempt; doesn't block
+item, ok := q.TryDequeue() // interface{} pointing to a string
+```
+
+`SPSCQueueOf[I]` is an implementation with parametrized item type. It is available for Go 1.19 or later.
+
+```go
+q := xsync.NewSPSCQueueOf[string](1024)
+inserted := q.TryEnqueue("foo")
+item, ok := q.TryDequeue() // string
+```
+
+The queue is based on the data structure from this [article](https://rigtorp.se/ringbuffer). The idea is to reduce the CPU cache coherency traffic by keeping cached copies of read and write indexes used by producer and consumer respectively.
+
+### MPMCQueue
+
+A `MPMCQueue` is a bounded multi-producer multi-consumer concurrent queue.
+
+```go
+q := xsync.NewMPMCQueue(1024)
+// producer optimistically inserts an item into the queue
+// optimistic insertion attempt; doesn't block
+inserted := q.TryEnqueue("bar")
+// consumer obtains an item from the queue
+// optimistic obtain attempt; doesn't block
+item, ok := q.TryDequeue() // interface{} pointing to a string
+```
+
+`MPMCQueueOf[I]` is an implementation with parametrized item type. It is available for Go 1.19 or later.
+
+```go
+q := xsync.NewMPMCQueueOf[string](1024)
+inserted := q.TryEnqueue("foo")
+item, ok := q.TryDequeue() // string
+```
+
+The queue is based on the algorithm from the [MPMCQueue](https://github.com/rigtorp/MPMCQueue) C++ library which in its turn references D.Vyukov's [MPMC queue](https://www.1024cores.net/home/lock-free-algorithms/queues/bounded-mpmc-queue). According to the following [classification](https://www.1024cores.net/home/lock-free-algorithms/queues), the queue is array-based, fails on overflow, provides causal FIFO, has blocking producers and consumers.
+
+The idea of the algorithm is to allow parallelism for concurrent producers and consumers by introducing the notion of tickets, i.e. values of two counters, one per producers/consumers. An atomic increment of one of those counters is the only noticeable contention point in queue operations. The rest of the operation avoids contention on writes thanks to the turn-based read/write access for each of the queue items.
+
+In essence, `MPMCQueue` is a specialized queue for scenarios where there are multiple concurrent producers and consumers of a single queue running on a large multicore machine.
+
+To get the optimal performance, you may want to set the queue size to be large enough, say, an order of magnitude greater than the number of producers/consumers, to allow producers and consumers to progress with their queue operations in parallel most of the time.
+
+### RBMutex
+
+A `RBMutex` is a reader-biased reader/writer mutual exclusion lock. The lock can be held by many readers or a single writer.
+
+```go
+mu := xsync.NewRBMutex()
+// reader lock calls return a token
+t := mu.RLock()
+// the token must be later used to unlock the mutex
+mu.RUnlock(t)
+// writer locks are the same as in sync.RWMutex
+mu.Lock()
+mu.Unlock()
+```
+
+`RBMutex` is based on a modified version of BRAVO (Biased Locking for Reader-Writer Locks) algorithm: https://arxiv.org/pdf/1810.01553.pdf
+
+The idea of the algorithm is to build on top of an existing reader-writer mutex and introduce a fast path for readers. On the fast path, reader lock attempts are sharded over an internal array based on the reader identity (a token in the case of Golang). This means that readers do not contend over a single atomic counter like it's done in, say, `sync.RWMutex` allowing for better scalability in terms of cores.
+
+Hence, by the design `RBMutex` is a specialized mutex for scenarios, such as caches, where the vast majority of locks are acquired by readers and write lock acquire attempts are infrequent. In such scenarios, `RBMutex` should perform better than the `sync.RWMutex` on large multicore machines.
+
+`RBMutex` extends `sync.RWMutex` internally and uses it as the "reader bias disabled" fallback, so the same semantics apply. The only noticeable difference is in the reader tokens returned from the `RLock`/`RUnlock` methods.
+
+Apart from blocking methods, `RBMutex` also has methods for optimistic locking:
+```go
+mu := xsync.NewRBMutex()
+if locked, t := mu.TryRLock(); locked {
+	// critical reader section...
+	mu.RUnlock(t)
+}
+if mu.TryLock() {
+	// critical writer section...
+	mu.Unlock()
+}
+```
+
+## License
+
+Licensed under MIT.

--- a/vendor/github.com/puzpuzpuz/xsync/v3/counter.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/counter.go
@@ -1,0 +1,99 @@
+package xsync
+
+import (
+	"sync"
+	"sync/atomic"
+)
+
+// pool for P tokens
+var ptokenPool sync.Pool
+
+// a P token is used to point at the current OS thread (P)
+// on which the goroutine is run; exact identity of the thread,
+// as well as P migration tolerance, is not important since
+// it's used to as a best effort mechanism for assigning
+// concurrent operations (goroutines) to different stripes of
+// the counter
+type ptoken struct {
+	idx uint32
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 4]byte
+}
+
+// A Counter is a striped int64 counter.
+//
+// Should be preferred over a single atomically updated int64
+// counter in high contention scenarios.
+//
+// A Counter must not be copied after first use.
+type Counter struct {
+	stripes []cstripe
+	mask    uint32
+}
+
+type cstripe struct {
+	c int64
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 8]byte
+}
+
+// NewCounter creates a new Counter instance.
+func NewCounter() *Counter {
+	nstripes := nextPowOf2(parallelism())
+	c := Counter{
+		stripes: make([]cstripe, nstripes),
+		mask:    nstripes - 1,
+	}
+	return &c
+}
+
+// Inc increments the counter by 1.
+func (c *Counter) Inc() {
+	c.Add(1)
+}
+
+// Dec decrements the counter by 1.
+func (c *Counter) Dec() {
+	c.Add(-1)
+}
+
+// Add adds the delta to the counter.
+func (c *Counter) Add(delta int64) {
+	t, ok := ptokenPool.Get().(*ptoken)
+	if !ok {
+		t = new(ptoken)
+		t.idx = runtime_fastrand()
+	}
+	for {
+		stripe := &c.stripes[t.idx&c.mask]
+		cnt := atomic.LoadInt64(&stripe.c)
+		if atomic.CompareAndSwapInt64(&stripe.c, cnt, cnt+delta) {
+			break
+		}
+		// Give a try with another randomly selected stripe.
+		t.idx = runtime_fastrand()
+	}
+	ptokenPool.Put(t)
+}
+
+// Value returns the current counter value.
+// The returned value may not include all of the latest operations in
+// presence of concurrent modifications of the counter.
+func (c *Counter) Value() int64 {
+	v := int64(0)
+	for i := 0; i < len(c.stripes); i++ {
+		stripe := &c.stripes[i]
+		v += atomic.LoadInt64(&stripe.c)
+	}
+	return v
+}
+
+// Reset resets the counter to zero.
+// This method should only be used when it is known that there are
+// no concurrent modifications of the counter.
+func (c *Counter) Reset() {
+	for i := 0; i < len(c.stripes); i++ {
+		stripe := &c.stripes[i]
+		atomic.StoreInt64(&stripe.c, 0)
+	}
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/map.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/map.go
@@ -1,0 +1,917 @@
+package xsync
+
+import (
+	"fmt"
+	"math"
+	"runtime"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+type mapResizeHint int
+
+const (
+	mapGrowHint   mapResizeHint = 0
+	mapShrinkHint mapResizeHint = 1
+	mapClearHint  mapResizeHint = 2
+)
+
+const (
+	// number of Map entries per bucket; 3 entries lead to size of 64B
+	// (one cache line) on 64-bit machines
+	entriesPerMapBucket = 3
+	// threshold fraction of table occupation to start a table shrinking
+	// when deleting the last entry in a bucket chain
+	mapShrinkFraction = 128
+	// map load factor to trigger a table resize during insertion;
+	// a map holds up to mapLoadFactor*entriesPerMapBucket*mapTableLen
+	// key-value pairs (this is a soft limit)
+	mapLoadFactor = 0.75
+	// minimal table size, i.e. number of buckets; thus, minimal map
+	// capacity can be calculated as entriesPerMapBucket*defaultMinMapTableLen
+	defaultMinMapTableLen = 32
+	// minimum counter stripes to use
+	minMapCounterLen = 8
+	// maximum counter stripes to use; stands for around 4KB of memory
+	maxMapCounterLen = 32
+)
+
+var (
+	topHashMask       = uint64((1<<20)-1) << 44
+	topHashEntryMasks = [3]uint64{
+		topHashMask,
+		topHashMask >> 20,
+		topHashMask >> 40,
+	}
+)
+
+// Map is like a Go map[string]interface{} but is safe for concurrent
+// use by multiple goroutines without additional locking or
+// coordination. It follows the interface of sync.Map with
+// a number of valuable extensions like Compute or Size.
+//
+// A Map must not be copied after first use.
+//
+// Map uses a modified version of Cache-Line Hash Table (CLHT)
+// data structure: https://github.com/LPD-EPFL/CLHT
+//
+// CLHT is built around idea to organize the hash table in
+// cache-line-sized buckets, so that on all modern CPUs update
+// operations complete with at most one cache-line transfer.
+// Also, Get operations involve no write to memory, as well as no
+// mutexes or any other sort of locks. Due to this design, in all
+// considered scenarios Map outperforms sync.Map.
+//
+// One important difference with sync.Map is that only string keys
+// are supported. That's because Golang standard library does not
+// expose the built-in hash functions for interface{} values.
+type Map struct {
+	totalGrowths int64
+	totalShrinks int64
+	resizing     int64          // resize in progress flag; updated atomically
+	resizeMu     sync.Mutex     // only used along with resizeCond
+	resizeCond   sync.Cond      // used to wake up resize waiters (concurrent modifications)
+	table        unsafe.Pointer // *mapTable
+	minTableLen  int
+	growOnly     bool
+}
+
+type mapTable struct {
+	buckets []bucketPadded
+	// striped counter for number of table entries;
+	// used to determine if a table shrinking is needed
+	// occupies min(buckets_memory/1024, 64KB) of memory
+	size []counterStripe
+	seed uint64
+}
+
+type counterStripe struct {
+	c int64
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 8]byte
+}
+
+type bucketPadded struct {
+	//lint:ignore U1000 ensure each bucket takes two cache lines on both 32 and 64-bit archs
+	pad [cacheLineSize - unsafe.Sizeof(bucket{})]byte
+	bucket
+}
+
+type bucket struct {
+	next   unsafe.Pointer // *bucketPadded
+	keys   [entriesPerMapBucket]unsafe.Pointer
+	values [entriesPerMapBucket]unsafe.Pointer
+	// topHashMutex is a 2-in-1 value.
+	//
+	// It contains packed top 20 bits (20 MSBs) of hash codes for keys
+	// stored in the bucket:
+	// | key 0's top hash | key 1's top hash | key 2's top hash | bitmap for keys | mutex |
+	// |      20 bits     |      20 bits     |      20 bits     |     3 bits      | 1 bit |
+	//
+	// The least significant bit is used for the mutex (TTAS spinlock).
+	topHashMutex uint64
+}
+
+type rangeEntry struct {
+	key   unsafe.Pointer
+	value unsafe.Pointer
+}
+
+// MapConfig defines configurable Map/MapOf options.
+type MapConfig struct {
+	sizeHint int
+	growOnly bool
+}
+
+// WithPresize configures new Map/MapOf instance with capacity enough
+// to hold sizeHint entries. The capacity is treated as the minimal
+// capacity meaning that the underlying hash table will never shrink
+// to a smaller capacity. If sizeHint is zero or negative, the value
+// is ignored.
+func WithPresize(sizeHint int) func(*MapConfig) {
+	return func(c *MapConfig) {
+		c.sizeHint = sizeHint
+	}
+}
+
+// WithGrowOnly configures new Map/MapOf instance to be grow-only.
+// This means that the underlying hash table grows in capacity when
+// new keys are added, but does not shrink when keys are deleted.
+// The only exception to this rule is the Clear method which
+// shrinks the hash table back to the initial capacity.
+func WithGrowOnly() func(*MapConfig) {
+	return func(c *MapConfig) {
+		c.growOnly = true
+	}
+}
+
+// NewMap creates a new Map instance configured with the given
+// options.
+func NewMap(options ...func(*MapConfig)) *Map {
+	c := &MapConfig{
+		sizeHint: defaultMinMapTableLen * entriesPerMapBucket,
+	}
+	for _, o := range options {
+		o(c)
+	}
+
+	m := &Map{}
+	m.resizeCond = *sync.NewCond(&m.resizeMu)
+	var table *mapTable
+	if c.sizeHint <= defaultMinMapTableLen*entriesPerMapBucket {
+		table = newMapTable(defaultMinMapTableLen)
+	} else {
+		tableLen := nextPowOf2(uint32((float64(c.sizeHint) / entriesPerMapBucket) / mapLoadFactor))
+		table = newMapTable(int(tableLen))
+	}
+	m.minTableLen = len(table.buckets)
+	m.growOnly = c.growOnly
+	atomic.StorePointer(&m.table, unsafe.Pointer(table))
+	return m
+}
+
+// NewMapPresized creates a new Map instance with capacity enough to hold
+// sizeHint entries. The capacity is treated as the minimal capacity
+// meaning that the underlying hash table will never shrink to
+// a smaller capacity. If sizeHint is zero or negative, the value
+// is ignored.
+//
+// Deprecated: use NewMap in combination with WithPresize.
+func NewMapPresized(sizeHint int) *Map {
+	return NewMap(WithPresize(sizeHint))
+}
+
+func newMapTable(minTableLen int) *mapTable {
+	buckets := make([]bucketPadded, minTableLen)
+	counterLen := minTableLen >> 10
+	if counterLen < minMapCounterLen {
+		counterLen = minMapCounterLen
+	} else if counterLen > maxMapCounterLen {
+		counterLen = maxMapCounterLen
+	}
+	counter := make([]counterStripe, counterLen)
+	t := &mapTable{
+		buckets: buckets,
+		size:    counter,
+		seed:    makeSeed(),
+	}
+	return t
+}
+
+// ToPlainMap returns a native map with a copy of xsync Map's
+// contents. The copied xsync Map should not be modified while
+// this call is made. If the copied Map is modified, the copying
+// behavior is the same as in the Range method.
+func ToPlainMap(m *Map) map[string]interface{} {
+	pm := make(map[string]interface{})
+	if m != nil {
+		m.Range(func(key string, value interface{}) bool {
+			pm[key] = value
+			return true
+		})
+	}
+	return pm
+}
+
+// Load returns the value stored in the map for a key, or nil if no
+// value is present.
+// The ok result indicates whether value was found in the map.
+func (m *Map) Load(key string) (value interface{}, ok bool) {
+	table := (*mapTable)(atomic.LoadPointer(&m.table))
+	hash := hashString(key, table.seed)
+	bidx := uint64(len(table.buckets)-1) & hash
+	b := &table.buckets[bidx]
+	for {
+		topHashes := atomic.LoadUint64(&b.topHashMutex)
+		for i := 0; i < entriesPerMapBucket; i++ {
+			if !topHashMatch(hash, topHashes, i) {
+				continue
+			}
+		atomic_snapshot:
+			// Start atomic snapshot.
+			vp := atomic.LoadPointer(&b.values[i])
+			kp := atomic.LoadPointer(&b.keys[i])
+			if kp != nil && vp != nil {
+				if key == derefKey(kp) {
+					if uintptr(vp) == uintptr(atomic.LoadPointer(&b.values[i])) {
+						// Atomic snapshot succeeded.
+						return derefValue(vp), true
+					}
+					// Concurrent update/remove. Go for another spin.
+					goto atomic_snapshot
+				}
+			}
+		}
+		bptr := atomic.LoadPointer(&b.next)
+		if bptr == nil {
+			return
+		}
+		b = (*bucketPadded)(bptr)
+	}
+}
+
+// Store sets the value for a key.
+func (m *Map) Store(key string, value interface{}) {
+	m.doCompute(
+		key,
+		func(interface{}, bool) (interface{}, bool) {
+			return value, false
+		},
+		false,
+		false,
+	)
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *Map) LoadOrStore(key string, value interface{}) (actual interface{}, loaded bool) {
+	return m.doCompute(
+		key,
+		func(interface{}, bool) (interface{}, bool) {
+			return value, false
+		},
+		true,
+		false,
+	)
+}
+
+// LoadAndStore returns the existing value for the key if present,
+// while setting the new value for the key.
+// It stores the new value and returns the existing one, if present.
+// The loaded result is true if the existing value was loaded,
+// false otherwise.
+func (m *Map) LoadAndStore(key string, value interface{}) (actual interface{}, loaded bool) {
+	return m.doCompute(
+		key,
+		func(interface{}, bool) (interface{}, bool) {
+			return value, false
+		},
+		false,
+		false,
+	)
+}
+
+// LoadOrCompute returns the existing value for the key if present.
+// Otherwise, it computes the value using the provided function, and
+// then stores and returns the computed value. The loaded result is
+// true if the value was loaded, false if computed.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *Map) LoadOrCompute(key string, valueFn func() interface{}) (actual interface{}, loaded bool) {
+	return m.doCompute(
+		key,
+		func(interface{}, bool) (interface{}, bool) {
+			return valueFn(), false
+		},
+		true,
+		false,
+	)
+}
+
+// LoadOrTryCompute returns the existing value for the key if present.
+// Otherwise, it tries to compute the value using the provided function
+// and, if successful, stores and returns the computed value. The loaded
+// result is true if the value was loaded, or false if computed (whether
+// successfully or not). If the compute attempt was cancelled (due to an
+// error, for example), a nil value will be returned.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *Map) LoadOrTryCompute(
+	key string,
+	valueFn func() (newValue interface{}, cancel bool),
+) (value interface{}, loaded bool) {
+	return m.doCompute(
+		key,
+		func(interface{}, bool) (interface{}, bool) {
+			nv, c := valueFn()
+			if !c {
+				return nv, false
+			}
+			return nil, true
+		},
+		true,
+		false,
+	)
+}
+
+// Compute either sets the computed new value for the key or deletes
+// the value for the key. When the delete result of the valueFn function
+// is set to true, the value will be deleted, if it exists. When delete
+// is set to false, the value is updated to the newValue.
+// The ok result indicates whether value was computed and stored, thus, is
+// present in the map. The actual result contains the new value in cases where
+// the value was computed and stored. See the example for a few use cases.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *Map) Compute(
+	key string,
+	valueFn func(oldValue interface{}, loaded bool) (newValue interface{}, delete bool),
+) (actual interface{}, ok bool) {
+	return m.doCompute(key, valueFn, false, true)
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous
+// value if any. The loaded result reports whether the key was
+// present.
+func (m *Map) LoadAndDelete(key string) (value interface{}, loaded bool) {
+	return m.doCompute(
+		key,
+		func(value interface{}, loaded bool) (interface{}, bool) {
+			return value, true
+		},
+		false,
+		false,
+	)
+}
+
+// Delete deletes the value for a key.
+func (m *Map) Delete(key string) {
+	m.doCompute(
+		key,
+		func(value interface{}, loaded bool) (interface{}, bool) {
+			return value, true
+		},
+		false,
+		false,
+	)
+}
+
+func (m *Map) doCompute(
+	key string,
+	valueFn func(oldValue interface{}, loaded bool) (interface{}, bool),
+	loadIfExists, computeOnly bool,
+) (interface{}, bool) {
+	// Read-only path.
+	if loadIfExists {
+		if v, ok := m.Load(key); ok {
+			return v, !computeOnly
+		}
+	}
+	// Write path.
+	for {
+	compute_attempt:
+		var (
+			emptyb       *bucketPadded
+			emptyidx     int
+			hintNonEmpty int
+		)
+		table := (*mapTable)(atomic.LoadPointer(&m.table))
+		tableLen := len(table.buckets)
+		hash := hashString(key, table.seed)
+		bidx := uint64(len(table.buckets)-1) & hash
+		rootb := &table.buckets[bidx]
+		lockBucket(&rootb.topHashMutex)
+		// The following two checks must go in reverse to what's
+		// in the resize method.
+		if m.resizeInProgress() {
+			// Resize is in progress. Wait, then go for another attempt.
+			unlockBucket(&rootb.topHashMutex)
+			m.waitForResize()
+			goto compute_attempt
+		}
+		if m.newerTableExists(table) {
+			// Someone resized the table. Go for another attempt.
+			unlockBucket(&rootb.topHashMutex)
+			goto compute_attempt
+		}
+		b := rootb
+		for {
+			topHashes := atomic.LoadUint64(&b.topHashMutex)
+			for i := 0; i < entriesPerMapBucket; i++ {
+				if b.keys[i] == nil {
+					if emptyb == nil {
+						emptyb = b
+						emptyidx = i
+					}
+					continue
+				}
+				if !topHashMatch(hash, topHashes, i) {
+					hintNonEmpty++
+					continue
+				}
+				if key == derefKey(b.keys[i]) {
+					vp := b.values[i]
+					if loadIfExists {
+						unlockBucket(&rootb.topHashMutex)
+						return derefValue(vp), !computeOnly
+					}
+					// In-place update/delete.
+					// We get a copy of the value via an interface{} on each call,
+					// thus the live value pointers are unique. Otherwise atomic
+					// snapshot won't be correct in case of multiple Store calls
+					// using the same value.
+					oldValue := derefValue(vp)
+					newValue, del := valueFn(oldValue, true)
+					if del {
+						// Deletion.
+						// First we update the value, then the key.
+						// This is important for atomic snapshot states.
+						atomic.StoreUint64(&b.topHashMutex, eraseTopHash(topHashes, i))
+						atomic.StorePointer(&b.values[i], nil)
+						atomic.StorePointer(&b.keys[i], nil)
+						leftEmpty := false
+						if hintNonEmpty == 0 {
+							leftEmpty = isEmptyBucket(b)
+						}
+						unlockBucket(&rootb.topHashMutex)
+						table.addSize(bidx, -1)
+						// Might need to shrink the table.
+						if leftEmpty {
+							m.resize(table, mapShrinkHint)
+						}
+						return oldValue, !computeOnly
+					}
+					nvp := unsafe.Pointer(&newValue)
+					if assertionsEnabled && vp == nvp {
+						panic("non-unique value pointer")
+					}
+					atomic.StorePointer(&b.values[i], nvp)
+					unlockBucket(&rootb.topHashMutex)
+					if computeOnly {
+						// Compute expects the new value to be returned.
+						return newValue, true
+					}
+					// LoadAndStore expects the old value to be returned.
+					return oldValue, true
+				}
+				hintNonEmpty++
+			}
+			if b.next == nil {
+				if emptyb != nil {
+					// Insertion into an existing bucket.
+					var zeroV interface{}
+					newValue, del := valueFn(zeroV, false)
+					if del {
+						unlockBucket(&rootb.topHashMutex)
+						return zeroV, false
+					}
+					// First we update the value, then the key.
+					// This is important for atomic snapshot states.
+					topHashes = atomic.LoadUint64(&emptyb.topHashMutex)
+					atomic.StoreUint64(&emptyb.topHashMutex, storeTopHash(hash, topHashes, emptyidx))
+					atomic.StorePointer(&emptyb.values[emptyidx], unsafe.Pointer(&newValue))
+					atomic.StorePointer(&emptyb.keys[emptyidx], unsafe.Pointer(&key))
+					unlockBucket(&rootb.topHashMutex)
+					table.addSize(bidx, 1)
+					return newValue, computeOnly
+				}
+				growThreshold := float64(tableLen) * entriesPerMapBucket * mapLoadFactor
+				if table.sumSize() > int64(growThreshold) {
+					// Need to grow the table. Then go for another attempt.
+					unlockBucket(&rootb.topHashMutex)
+					m.resize(table, mapGrowHint)
+					goto compute_attempt
+				}
+				// Insertion into a new bucket.
+				var zeroV interface{}
+				newValue, del := valueFn(zeroV, false)
+				if del {
+					unlockBucket(&rootb.topHashMutex)
+					return newValue, false
+				}
+				// Create and append a bucket.
+				newb := new(bucketPadded)
+				newb.keys[0] = unsafe.Pointer(&key)
+				newb.values[0] = unsafe.Pointer(&newValue)
+				newb.topHashMutex = storeTopHash(hash, newb.topHashMutex, 0)
+				atomic.StorePointer(&b.next, unsafe.Pointer(newb))
+				unlockBucket(&rootb.topHashMutex)
+				table.addSize(bidx, 1)
+				return newValue, computeOnly
+			}
+			b = (*bucketPadded)(b.next)
+		}
+	}
+}
+
+func (m *Map) newerTableExists(table *mapTable) bool {
+	curTablePtr := atomic.LoadPointer(&m.table)
+	return uintptr(curTablePtr) != uintptr(unsafe.Pointer(table))
+}
+
+func (m *Map) resizeInProgress() bool {
+	return atomic.LoadInt64(&m.resizing) == 1
+}
+
+func (m *Map) waitForResize() {
+	m.resizeMu.Lock()
+	for m.resizeInProgress() {
+		m.resizeCond.Wait()
+	}
+	m.resizeMu.Unlock()
+}
+
+func (m *Map) resize(knownTable *mapTable, hint mapResizeHint) {
+	knownTableLen := len(knownTable.buckets)
+	// Fast path for shrink attempts.
+	if hint == mapShrinkHint {
+		if m.growOnly ||
+			m.minTableLen == knownTableLen ||
+			knownTable.sumSize() > int64((knownTableLen*entriesPerMapBucket)/mapShrinkFraction) {
+			return
+		}
+	}
+	// Slow path.
+	if !atomic.CompareAndSwapInt64(&m.resizing, 0, 1) {
+		// Someone else started resize. Wait for it to finish.
+		m.waitForResize()
+		return
+	}
+	var newTable *mapTable
+	table := (*mapTable)(atomic.LoadPointer(&m.table))
+	tableLen := len(table.buckets)
+	switch hint {
+	case mapGrowHint:
+		// Grow the table with factor of 2.
+		atomic.AddInt64(&m.totalGrowths, 1)
+		newTable = newMapTable(tableLen << 1)
+	case mapShrinkHint:
+		shrinkThreshold := int64((tableLen * entriesPerMapBucket) / mapShrinkFraction)
+		if tableLen > m.minTableLen && table.sumSize() <= shrinkThreshold {
+			// Shrink the table with factor of 2.
+			atomic.AddInt64(&m.totalShrinks, 1)
+			newTable = newMapTable(tableLen >> 1)
+		} else {
+			// No need to shrink. Wake up all waiters and give up.
+			m.resizeMu.Lock()
+			atomic.StoreInt64(&m.resizing, 0)
+			m.resizeCond.Broadcast()
+			m.resizeMu.Unlock()
+			return
+		}
+	case mapClearHint:
+		newTable = newMapTable(m.minTableLen)
+	default:
+		panic(fmt.Sprintf("unexpected resize hint: %d", hint))
+	}
+	// Copy the data only if we're not clearing the map.
+	if hint != mapClearHint {
+		for i := 0; i < tableLen; i++ {
+			copied := copyBucket(&table.buckets[i], newTable)
+			newTable.addSizePlain(uint64(i), copied)
+		}
+	}
+	// Publish the new table and wake up all waiters.
+	atomic.StorePointer(&m.table, unsafe.Pointer(newTable))
+	m.resizeMu.Lock()
+	atomic.StoreInt64(&m.resizing, 0)
+	m.resizeCond.Broadcast()
+	m.resizeMu.Unlock()
+}
+
+func copyBucket(b *bucketPadded, destTable *mapTable) (copied int) {
+	rootb := b
+	lockBucket(&rootb.topHashMutex)
+	for {
+		for i := 0; i < entriesPerMapBucket; i++ {
+			if b.keys[i] != nil {
+				k := derefKey(b.keys[i])
+				hash := hashString(k, destTable.seed)
+				bidx := uint64(len(destTable.buckets)-1) & hash
+				destb := &destTable.buckets[bidx]
+				appendToBucket(hash, b.keys[i], b.values[i], destb)
+				copied++
+			}
+		}
+		if b.next == nil {
+			unlockBucket(&rootb.topHashMutex)
+			return
+		}
+		b = (*bucketPadded)(b.next)
+	}
+}
+
+func appendToBucket(hash uint64, keyPtr, valPtr unsafe.Pointer, b *bucketPadded) {
+	for {
+		for i := 0; i < entriesPerMapBucket; i++ {
+			if b.keys[i] == nil {
+				b.keys[i] = keyPtr
+				b.values[i] = valPtr
+				b.topHashMutex = storeTopHash(hash, b.topHashMutex, i)
+				return
+			}
+		}
+		if b.next == nil {
+			newb := new(bucketPadded)
+			newb.keys[0] = keyPtr
+			newb.values[0] = valPtr
+			newb.topHashMutex = storeTopHash(hash, newb.topHashMutex, 0)
+			b.next = unsafe.Pointer(newb)
+			return
+		}
+		b = (*bucketPadded)(b.next)
+	}
+}
+
+func isEmptyBucket(rootb *bucketPadded) bool {
+	b := rootb
+	for {
+		for i := 0; i < entriesPerMapBucket; i++ {
+			if b.keys[i] != nil {
+				return false
+			}
+		}
+		if b.next == nil {
+			return true
+		}
+		b = (*bucketPadded)(b.next)
+	}
+}
+
+// Range calls f sequentially for each key and value present in the
+// map. If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot
+// of the Map's contents: no key will be visited more than once, but
+// if the value for any key is stored or deleted concurrently, Range
+// may reflect any mapping for that key from any point during the
+// Range call.
+//
+// It is safe to modify the map while iterating it, including entry
+// creation, modification and deletion. However, the concurrent
+// modification rule apply, i.e. the changes may be not reflected
+// in the subsequently iterated entries.
+func (m *Map) Range(f func(key string, value interface{}) bool) {
+	var zeroEntry rangeEntry
+	// Pre-allocate array big enough to fit entries for most hash tables.
+	bentries := make([]rangeEntry, 0, 16*entriesPerMapBucket)
+	tablep := atomic.LoadPointer(&m.table)
+	table := *(*mapTable)(tablep)
+	for i := range table.buckets {
+		rootb := &table.buckets[i]
+		b := rootb
+		// Prevent concurrent modifications and copy all entries into
+		// the intermediate slice.
+		lockBucket(&rootb.topHashMutex)
+		for {
+			for i := 0; i < entriesPerMapBucket; i++ {
+				if b.keys[i] != nil {
+					bentries = append(bentries, rangeEntry{
+						key:   b.keys[i],
+						value: b.values[i],
+					})
+				}
+			}
+			if b.next == nil {
+				unlockBucket(&rootb.topHashMutex)
+				break
+			}
+			b = (*bucketPadded)(b.next)
+		}
+		// Call the function for all copied entries.
+		for j := range bentries {
+			k := derefKey(bentries[j].key)
+			v := derefValue(bentries[j].value)
+			if !f(k, v) {
+				return
+			}
+			// Remove the reference to avoid preventing the copied
+			// entries from being GCed until this method finishes.
+			bentries[j] = zeroEntry
+		}
+		bentries = bentries[:0]
+	}
+}
+
+// Clear deletes all keys and values currently stored in the map.
+func (m *Map) Clear() {
+	table := (*mapTable)(atomic.LoadPointer(&m.table))
+	m.resize(table, mapClearHint)
+}
+
+// Size returns current size of the map.
+func (m *Map) Size() int {
+	table := (*mapTable)(atomic.LoadPointer(&m.table))
+	return int(table.sumSize())
+}
+
+func derefKey(keyPtr unsafe.Pointer) string {
+	return *(*string)(keyPtr)
+}
+
+func derefValue(valuePtr unsafe.Pointer) interface{} {
+	return *(*interface{})(valuePtr)
+}
+
+func lockBucket(mu *uint64) {
+	for {
+		var v uint64
+		for {
+			v = atomic.LoadUint64(mu)
+			if v&1 != 1 {
+				break
+			}
+			runtime.Gosched()
+		}
+		if atomic.CompareAndSwapUint64(mu, v, v|1) {
+			return
+		}
+		runtime.Gosched()
+	}
+}
+
+func unlockBucket(mu *uint64) {
+	v := atomic.LoadUint64(mu)
+	atomic.StoreUint64(mu, v&^1)
+}
+
+func topHashMatch(hash, topHashes uint64, idx int) bool {
+	if topHashes&(1<<(idx+1)) == 0 {
+		// Entry is not present.
+		return false
+	}
+	hash = hash & topHashMask
+	topHashes = (topHashes & topHashEntryMasks[idx]) << (20 * idx)
+	return hash == topHashes
+}
+
+func storeTopHash(hash, topHashes uint64, idx int) uint64 {
+	// Zero out top hash at idx.
+	topHashes = topHashes &^ topHashEntryMasks[idx]
+	// Chop top 20 MSBs of the given hash and position them at idx.
+	hash = (hash & topHashMask) >> (20 * idx)
+	// Store the MSBs.
+	topHashes = topHashes | hash
+	// Mark the entry as present.
+	return topHashes | (1 << (idx + 1))
+}
+
+func eraseTopHash(topHashes uint64, idx int) uint64 {
+	return topHashes &^ (1 << (idx + 1))
+}
+
+func (table *mapTable) addSize(bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
+	atomic.AddInt64(&table.size[cidx].c, int64(delta))
+}
+
+func (table *mapTable) addSizePlain(bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
+	table.size[cidx].c += int64(delta)
+}
+
+func (table *mapTable) sumSize() int64 {
+	sum := int64(0)
+	for i := range table.size {
+		sum += atomic.LoadInt64(&table.size[i].c)
+	}
+	return sum
+}
+
+// MapStats is Map/MapOf statistics.
+//
+// Warning: map statistics are intented to be used for diagnostic
+// purposes, not for production code. This means that breaking changes
+// may be introduced into this struct even between minor releases.
+type MapStats struct {
+	// RootBuckets is the number of root buckets in the hash table.
+	// Each bucket holds a few entries.
+	RootBuckets int
+	// TotalBuckets is the total number of buckets in the hash table,
+	// including root and their chained buckets. Each bucket holds
+	// a few entries.
+	TotalBuckets int
+	// EmptyBuckets is the number of buckets that hold no entries.
+	EmptyBuckets int
+	// Capacity is the Map/MapOf capacity, i.e. the total number of
+	// entries that all buckets can physically hold. This number
+	// does not consider the load factor.
+	Capacity int
+	// Size is the exact number of entries stored in the map.
+	Size int
+	// Counter is the number of entries stored in the map according
+	// to the internal atomic counter. In case of concurrent map
+	// modifications this number may be different from Size.
+	Counter int
+	// CounterLen is the number of internal atomic counter stripes.
+	// This number may grow with the map capacity to improve
+	// multithreaded scalability.
+	CounterLen int
+	// MinEntries is the minimum number of entries per a chain of
+	// buckets, i.e. a root bucket and its chained buckets.
+	MinEntries int
+	// MinEntries is the maximum number of entries per a chain of
+	// buckets, i.e. a root bucket and its chained buckets.
+	MaxEntries int
+	// TotalGrowths is the number of times the hash table grew.
+	TotalGrowths int64
+	// TotalGrowths is the number of times the hash table shrinked.
+	TotalShrinks int64
+}
+
+// ToString returns string representation of map stats.
+func (s *MapStats) ToString() string {
+	var sb strings.Builder
+	sb.WriteString("MapStats{\n")
+	sb.WriteString(fmt.Sprintf("RootBuckets:  %d\n", s.RootBuckets))
+	sb.WriteString(fmt.Sprintf("TotalBuckets: %d\n", s.TotalBuckets))
+	sb.WriteString(fmt.Sprintf("EmptyBuckets: %d\n", s.EmptyBuckets))
+	sb.WriteString(fmt.Sprintf("Capacity:     %d\n", s.Capacity))
+	sb.WriteString(fmt.Sprintf("Size:         %d\n", s.Size))
+	sb.WriteString(fmt.Sprintf("Counter:      %d\n", s.Counter))
+	sb.WriteString(fmt.Sprintf("CounterLen:   %d\n", s.CounterLen))
+	sb.WriteString(fmt.Sprintf("MinEntries:   %d\n", s.MinEntries))
+	sb.WriteString(fmt.Sprintf("MaxEntries:   %d\n", s.MaxEntries))
+	sb.WriteString(fmt.Sprintf("TotalGrowths: %d\n", s.TotalGrowths))
+	sb.WriteString(fmt.Sprintf("TotalShrinks: %d\n", s.TotalShrinks))
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+// Stats returns statistics for the Map. Just like other map
+// methods, this one is thread-safe. Yet it's an O(N) operation,
+// so it should be used only for diagnostics or debugging purposes.
+func (m *Map) Stats() MapStats {
+	stats := MapStats{
+		TotalGrowths: atomic.LoadInt64(&m.totalGrowths),
+		TotalShrinks: atomic.LoadInt64(&m.totalShrinks),
+		MinEntries:   math.MaxInt32,
+	}
+	table := (*mapTable)(atomic.LoadPointer(&m.table))
+	stats.RootBuckets = len(table.buckets)
+	stats.Counter = int(table.sumSize())
+	stats.CounterLen = len(table.size)
+	for i := range table.buckets {
+		nentries := 0
+		b := &table.buckets[i]
+		stats.TotalBuckets++
+		for {
+			nentriesLocal := 0
+			stats.Capacity += entriesPerMapBucket
+			for i := 0; i < entriesPerMapBucket; i++ {
+				if atomic.LoadPointer(&b.keys[i]) != nil {
+					stats.Size++
+					nentriesLocal++
+				}
+			}
+			nentries += nentriesLocal
+			if nentriesLocal == 0 {
+				stats.EmptyBuckets++
+			}
+			if b.next == nil {
+				break
+			}
+			b = (*bucketPadded)(atomic.LoadPointer(&b.next))
+			stats.TotalBuckets++
+		}
+		if nentries < stats.MinEntries {
+			stats.MinEntries = nentries
+		}
+		if nentries > stats.MaxEntries {
+			stats.MaxEntries = nentries
+		}
+	}
+	return stats
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/mapof.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/mapof.go
@@ -1,0 +1,738 @@
+package xsync
+
+import (
+	"fmt"
+	"math"
+	"sync"
+	"sync/atomic"
+	"unsafe"
+)
+
+const (
+	// number of MapOf entries per bucket; 5 entries lead to size of 64B
+	// (one cache line) on 64-bit machines
+	entriesPerMapOfBucket        = 5
+	defaultMeta           uint64 = 0x8080808080808080
+	metaMask              uint64 = 0xffffffffff
+	defaultMetaMasked     uint64 = defaultMeta & metaMask
+	emptyMetaSlot         uint8  = 0x80
+)
+
+// MapOf is like a Go map[K]V but is safe for concurrent
+// use by multiple goroutines without additional locking or
+// coordination. It follows the interface of sync.Map with
+// a number of valuable extensions like Compute or Size.
+//
+// A MapOf must not be copied after first use.
+//
+// MapOf uses a modified version of Cache-Line Hash Table (CLHT)
+// data structure: https://github.com/LPD-EPFL/CLHT
+//
+// CLHT is built around idea to organize the hash table in
+// cache-line-sized buckets, so that on all modern CPUs update
+// operations complete with at most one cache-line transfer.
+// Also, Get operations involve no write to memory, as well as no
+// mutexes or any other sort of locks. Due to this design, in all
+// considered scenarios MapOf outperforms sync.Map.
+//
+// MapOf also borrows ideas from Java's j.u.c.ConcurrentHashMap
+// (immutable K/V pair structs instead of atomic snapshots)
+// and C++'s absl::flat_hash_map (meta memory and SWAR-based
+// lookups).
+type MapOf[K comparable, V any] struct {
+	totalGrowths int64
+	totalShrinks int64
+	resizing     int64          // resize in progress flag; updated atomically
+	resizeMu     sync.Mutex     // only used along with resizeCond
+	resizeCond   sync.Cond      // used to wake up resize waiters (concurrent modifications)
+	table        unsafe.Pointer // *mapOfTable
+	hasher       func(K, uint64) uint64
+	minTableLen  int
+	growOnly     bool
+}
+
+type mapOfTable[K comparable, V any] struct {
+	buckets []bucketOfPadded
+	// striped counter for number of table entries;
+	// used to determine if a table shrinking is needed
+	// occupies min(buckets_memory/1024, 64KB) of memory
+	size []counterStripe
+	seed uint64
+}
+
+// bucketOfPadded is a CL-sized map bucket holding up to
+// entriesPerMapOfBucket entries.
+type bucketOfPadded struct {
+	//lint:ignore U1000 ensure each bucket takes two cache lines on both 32 and 64-bit archs
+	pad [cacheLineSize - unsafe.Sizeof(bucketOf{})]byte
+	bucketOf
+}
+
+type bucketOf struct {
+	meta    uint64
+	entries [entriesPerMapOfBucket]unsafe.Pointer // *entryOf
+	next    unsafe.Pointer                        // *bucketOfPadded
+	mu      sync.Mutex
+}
+
+// entryOf is an immutable map entry.
+type entryOf[K comparable, V any] struct {
+	key   K
+	value V
+}
+
+// NewMapOf creates a new MapOf instance configured with the given
+// options.
+func NewMapOf[K comparable, V any](options ...func(*MapConfig)) *MapOf[K, V] {
+	return NewMapOfWithHasher[K, V](defaultHasher[K](), options...)
+}
+
+// NewMapOfWithHasher creates a new MapOf instance configured with
+// the given hasher and options. The hash function is used instead
+// of the built-in hash function configured when a map is created
+// with the NewMapOf function.
+func NewMapOfWithHasher[K comparable, V any](
+	hasher func(K, uint64) uint64,
+	options ...func(*MapConfig),
+) *MapOf[K, V] {
+	c := &MapConfig{
+		sizeHint: defaultMinMapTableLen * entriesPerMapOfBucket,
+	}
+	for _, o := range options {
+		o(c)
+	}
+
+	m := &MapOf[K, V]{}
+	m.resizeCond = *sync.NewCond(&m.resizeMu)
+	m.hasher = hasher
+	var table *mapOfTable[K, V]
+	if c.sizeHint <= defaultMinMapTableLen*entriesPerMapOfBucket {
+		table = newMapOfTable[K, V](defaultMinMapTableLen)
+	} else {
+		tableLen := nextPowOf2(uint32((float64(c.sizeHint) / entriesPerMapOfBucket) / mapLoadFactor))
+		table = newMapOfTable[K, V](int(tableLen))
+	}
+	m.minTableLen = len(table.buckets)
+	m.growOnly = c.growOnly
+	atomic.StorePointer(&m.table, unsafe.Pointer(table))
+	return m
+}
+
+// NewMapOfPresized creates a new MapOf instance with capacity enough
+// to hold sizeHint entries. The capacity is treated as the minimal capacity
+// meaning that the underlying hash table will never shrink to
+// a smaller capacity. If sizeHint is zero or negative, the value
+// is ignored.
+//
+// Deprecated: use NewMapOf in combination with WithPresize.
+func NewMapOfPresized[K comparable, V any](sizeHint int) *MapOf[K, V] {
+	return NewMapOf[K, V](WithPresize(sizeHint))
+}
+
+func newMapOfTable[K comparable, V any](minTableLen int) *mapOfTable[K, V] {
+	buckets := make([]bucketOfPadded, minTableLen)
+	for i := range buckets {
+		buckets[i].meta = defaultMeta
+	}
+	counterLen := minTableLen >> 10
+	if counterLen < minMapCounterLen {
+		counterLen = minMapCounterLen
+	} else if counterLen > maxMapCounterLen {
+		counterLen = maxMapCounterLen
+	}
+	counter := make([]counterStripe, counterLen)
+	t := &mapOfTable[K, V]{
+		buckets: buckets,
+		size:    counter,
+		seed:    makeSeed(),
+	}
+	return t
+}
+
+// ToPlainMapOf returns a native map with a copy of xsync Map's
+// contents. The copied xsync Map should not be modified while
+// this call is made. If the copied Map is modified, the copying
+// behavior is the same as in the Range method.
+func ToPlainMapOf[K comparable, V any](m *MapOf[K, V]) map[K]V {
+	pm := make(map[K]V)
+	if m != nil {
+		m.Range(func(key K, value V) bool {
+			pm[key] = value
+			return true
+		})
+	}
+	return pm
+}
+
+// Load returns the value stored in the map for a key, or zero value
+// of type V if no value is present.
+// The ok result indicates whether value was found in the map.
+func (m *MapOf[K, V]) Load(key K) (value V, ok bool) {
+	table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+	hash := m.hasher(key, table.seed)
+	h1 := h1(hash)
+	h2w := broadcast(h2(hash))
+	bidx := uint64(len(table.buckets)-1) & h1
+	b := &table.buckets[bidx]
+	for {
+		metaw := atomic.LoadUint64(&b.meta)
+		markedw := markZeroBytes(metaw^h2w) & metaMask
+		for markedw != 0 {
+			idx := firstMarkedByteIndex(markedw)
+			eptr := atomic.LoadPointer(&b.entries[idx])
+			if eptr != nil {
+				e := (*entryOf[K, V])(eptr)
+				if e.key == key {
+					return e.value, true
+				}
+			}
+			markedw &= markedw - 1
+		}
+		bptr := atomic.LoadPointer(&b.next)
+		if bptr == nil {
+			return
+		}
+		b = (*bucketOfPadded)(bptr)
+	}
+}
+
+// Store sets the value for a key.
+func (m *MapOf[K, V]) Store(key K, value V) {
+	m.doCompute(
+		key,
+		func(V, bool) (V, bool) {
+			return value, false
+		},
+		false,
+		false,
+	)
+}
+
+// LoadOrStore returns the existing value for the key if present.
+// Otherwise, it stores and returns the given value.
+// The loaded result is true if the value was loaded, false if stored.
+func (m *MapOf[K, V]) LoadOrStore(key K, value V) (actual V, loaded bool) {
+	return m.doCompute(
+		key,
+		func(V, bool) (V, bool) {
+			return value, false
+		},
+		true,
+		false,
+	)
+}
+
+// LoadAndStore returns the existing value for the key if present,
+// while setting the new value for the key.
+// It stores the new value and returns the existing one, if present.
+// The loaded result is true if the existing value was loaded,
+// false otherwise.
+func (m *MapOf[K, V]) LoadAndStore(key K, value V) (actual V, loaded bool) {
+	return m.doCompute(
+		key,
+		func(V, bool) (V, bool) {
+			return value, false
+		},
+		false,
+		false,
+	)
+}
+
+// LoadOrCompute returns the existing value for the key if present.
+// Otherwise, it computes the value using the provided function, and
+// then stores and returns the computed value. The loaded result is
+// true if the value was loaded, false if computed.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *MapOf[K, V]) LoadOrCompute(key K, valueFn func() V) (actual V, loaded bool) {
+	return m.doCompute(
+		key,
+		func(V, bool) (V, bool) {
+			return valueFn(), false
+		},
+		true,
+		false,
+	)
+}
+
+// LoadOrTryCompute returns the existing value for the key if present.
+// Otherwise, it tries to compute the value using the provided function
+// and, if successful, stores and returns the computed value. The loaded
+// result is true if the value was loaded, or false if computed (whether
+// successfully or not). If the compute attempt was cancelled (due to an
+// error, for example), a zero value of type V will be returned.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *MapOf[K, V]) LoadOrTryCompute(
+	key K,
+	valueFn func() (newValue V, cancel bool),
+) (value V, loaded bool) {
+	return m.doCompute(
+		key,
+		func(V, bool) (V, bool) {
+			nv, c := valueFn()
+			if !c {
+				return nv, false
+			}
+			return nv, true // nv is ignored
+		},
+		true,
+		false,
+	)
+}
+
+// Compute either sets the computed new value for the key or deletes
+// the value for the key. When the delete result of the valueFn function
+// is set to true, the value will be deleted, if it exists. When delete
+// is set to false, the value is updated to the newValue.
+// The ok result indicates whether value was computed and stored, thus, is
+// present in the map. The actual result contains the new value in cases where
+// the value was computed and stored. See the example for a few use cases.
+//
+// This call locks a hash table bucket while the compute function
+// is executed. It means that modifications on other entries in
+// the bucket will be blocked until the valueFn executes. Consider
+// this when the function includes long-running operations.
+func (m *MapOf[K, V]) Compute(
+	key K,
+	valueFn func(oldValue V, loaded bool) (newValue V, delete bool),
+) (actual V, ok bool) {
+	return m.doCompute(key, valueFn, false, true)
+}
+
+// LoadAndDelete deletes the value for a key, returning the previous
+// value if any. The loaded result reports whether the key was
+// present.
+func (m *MapOf[K, V]) LoadAndDelete(key K) (value V, loaded bool) {
+	return m.doCompute(
+		key,
+		func(value V, loaded bool) (V, bool) {
+			return value, true
+		},
+		false,
+		false,
+	)
+}
+
+// Delete deletes the value for a key.
+func (m *MapOf[K, V]) Delete(key K) {
+	m.doCompute(
+		key,
+		func(value V, loaded bool) (V, bool) {
+			return value, true
+		},
+		false,
+		false,
+	)
+}
+
+func (m *MapOf[K, V]) doCompute(
+	key K,
+	valueFn func(oldValue V, loaded bool) (V, bool),
+	loadIfExists, computeOnly bool,
+) (V, bool) {
+	// Read-only path.
+	if loadIfExists {
+		if v, ok := m.Load(key); ok {
+			return v, !computeOnly
+		}
+	}
+	// Write path.
+	for {
+	compute_attempt:
+		var (
+			emptyb   *bucketOfPadded
+			emptyidx int
+		)
+		table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+		tableLen := len(table.buckets)
+		hash := m.hasher(key, table.seed)
+		h1 := h1(hash)
+		h2 := h2(hash)
+		h2w := broadcast(h2)
+		bidx := uint64(len(table.buckets)-1) & h1
+		rootb := &table.buckets[bidx]
+		rootb.mu.Lock()
+		// The following two checks must go in reverse to what's
+		// in the resize method.
+		if m.resizeInProgress() {
+			// Resize is in progress. Wait, then go for another attempt.
+			rootb.mu.Unlock()
+			m.waitForResize()
+			goto compute_attempt
+		}
+		if m.newerTableExists(table) {
+			// Someone resized the table. Go for another attempt.
+			rootb.mu.Unlock()
+			goto compute_attempt
+		}
+		b := rootb
+		for {
+			metaw := b.meta
+			markedw := markZeroBytes(metaw^h2w) & metaMask
+			for markedw != 0 {
+				idx := firstMarkedByteIndex(markedw)
+				eptr := b.entries[idx]
+				if eptr != nil {
+					e := (*entryOf[K, V])(eptr)
+					if e.key == key {
+						if loadIfExists {
+							rootb.mu.Unlock()
+							return e.value, !computeOnly
+						}
+						// In-place update/delete.
+						// We get a copy of the value via an interface{} on each call,
+						// thus the live value pointers are unique. Otherwise atomic
+						// snapshot won't be correct in case of multiple Store calls
+						// using the same value.
+						oldv := e.value
+						newv, del := valueFn(oldv, true)
+						if del {
+							// Deletion.
+							// First we update the hash, then the entry.
+							newmetaw := setByte(metaw, emptyMetaSlot, idx)
+							atomic.StoreUint64(&b.meta, newmetaw)
+							atomic.StorePointer(&b.entries[idx], nil)
+							rootb.mu.Unlock()
+							table.addSize(bidx, -1)
+							// Might need to shrink the table if we left bucket empty.
+							if newmetaw == defaultMeta {
+								m.resize(table, mapShrinkHint)
+							}
+							return oldv, !computeOnly
+						}
+						newe := new(entryOf[K, V])
+						newe.key = key
+						newe.value = newv
+						atomic.StorePointer(&b.entries[idx], unsafe.Pointer(newe))
+						rootb.mu.Unlock()
+						if computeOnly {
+							// Compute expects the new value to be returned.
+							return newv, true
+						}
+						// LoadAndStore expects the old value to be returned.
+						return oldv, true
+					}
+				}
+				markedw &= markedw - 1
+			}
+			if emptyb == nil {
+				// Search for empty entries (up to 5 per bucket).
+				emptyw := metaw & defaultMetaMasked
+				if emptyw != 0 {
+					idx := firstMarkedByteIndex(emptyw)
+					emptyb = b
+					emptyidx = idx
+				}
+			}
+			if b.next == nil {
+				if emptyb != nil {
+					// Insertion into an existing bucket.
+					var zeroV V
+					newValue, del := valueFn(zeroV, false)
+					if del {
+						rootb.mu.Unlock()
+						return zeroV, false
+					}
+					newe := new(entryOf[K, V])
+					newe.key = key
+					newe.value = newValue
+					// First we update meta, then the entry.
+					atomic.StoreUint64(&emptyb.meta, setByte(emptyb.meta, h2, emptyidx))
+					atomic.StorePointer(&emptyb.entries[emptyidx], unsafe.Pointer(newe))
+					rootb.mu.Unlock()
+					table.addSize(bidx, 1)
+					return newValue, computeOnly
+				}
+				growThreshold := float64(tableLen) * entriesPerMapOfBucket * mapLoadFactor
+				if table.sumSize() > int64(growThreshold) {
+					// Need to grow the table. Then go for another attempt.
+					rootb.mu.Unlock()
+					m.resize(table, mapGrowHint)
+					goto compute_attempt
+				}
+				// Insertion into a new bucket.
+				var zeroV V
+				newValue, del := valueFn(zeroV, false)
+				if del {
+					rootb.mu.Unlock()
+					return newValue, false
+				}
+				// Create and append a bucket.
+				newb := new(bucketOfPadded)
+				newb.meta = setByte(defaultMeta, h2, 0)
+				newe := new(entryOf[K, V])
+				newe.key = key
+				newe.value = newValue
+				newb.entries[0] = unsafe.Pointer(newe)
+				atomic.StorePointer(&b.next, unsafe.Pointer(newb))
+				rootb.mu.Unlock()
+				table.addSize(bidx, 1)
+				return newValue, computeOnly
+			}
+			b = (*bucketOfPadded)(b.next)
+		}
+	}
+}
+
+func (m *MapOf[K, V]) newerTableExists(table *mapOfTable[K, V]) bool {
+	curTablePtr := atomic.LoadPointer(&m.table)
+	return uintptr(curTablePtr) != uintptr(unsafe.Pointer(table))
+}
+
+func (m *MapOf[K, V]) resizeInProgress() bool {
+	return atomic.LoadInt64(&m.resizing) == 1
+}
+
+func (m *MapOf[K, V]) waitForResize() {
+	m.resizeMu.Lock()
+	for m.resizeInProgress() {
+		m.resizeCond.Wait()
+	}
+	m.resizeMu.Unlock()
+}
+
+func (m *MapOf[K, V]) resize(knownTable *mapOfTable[K, V], hint mapResizeHint) {
+	knownTableLen := len(knownTable.buckets)
+	// Fast path for shrink attempts.
+	if hint == mapShrinkHint {
+		if m.growOnly ||
+			m.minTableLen == knownTableLen ||
+			knownTable.sumSize() > int64((knownTableLen*entriesPerMapOfBucket)/mapShrinkFraction) {
+			return
+		}
+	}
+	// Slow path.
+	if !atomic.CompareAndSwapInt64(&m.resizing, 0, 1) {
+		// Someone else started resize. Wait for it to finish.
+		m.waitForResize()
+		return
+	}
+	var newTable *mapOfTable[K, V]
+	table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+	tableLen := len(table.buckets)
+	switch hint {
+	case mapGrowHint:
+		// Grow the table with factor of 2.
+		atomic.AddInt64(&m.totalGrowths, 1)
+		newTable = newMapOfTable[K, V](tableLen << 1)
+	case mapShrinkHint:
+		shrinkThreshold := int64((tableLen * entriesPerMapOfBucket) / mapShrinkFraction)
+		if tableLen > m.minTableLen && table.sumSize() <= shrinkThreshold {
+			// Shrink the table with factor of 2.
+			atomic.AddInt64(&m.totalShrinks, 1)
+			newTable = newMapOfTable[K, V](tableLen >> 1)
+		} else {
+			// No need to shrink. Wake up all waiters and give up.
+			m.resizeMu.Lock()
+			atomic.StoreInt64(&m.resizing, 0)
+			m.resizeCond.Broadcast()
+			m.resizeMu.Unlock()
+			return
+		}
+	case mapClearHint:
+		newTable = newMapOfTable[K, V](m.minTableLen)
+	default:
+		panic(fmt.Sprintf("unexpected resize hint: %d", hint))
+	}
+	// Copy the data only if we're not clearing the map.
+	if hint != mapClearHint {
+		for i := 0; i < tableLen; i++ {
+			copied := copyBucketOf(&table.buckets[i], newTable, m.hasher)
+			newTable.addSizePlain(uint64(i), copied)
+		}
+	}
+	// Publish the new table and wake up all waiters.
+	atomic.StorePointer(&m.table, unsafe.Pointer(newTable))
+	m.resizeMu.Lock()
+	atomic.StoreInt64(&m.resizing, 0)
+	m.resizeCond.Broadcast()
+	m.resizeMu.Unlock()
+}
+
+func copyBucketOf[K comparable, V any](
+	b *bucketOfPadded,
+	destTable *mapOfTable[K, V],
+	hasher func(K, uint64) uint64,
+) (copied int) {
+	rootb := b
+	rootb.mu.Lock()
+	for {
+		for i := 0; i < entriesPerMapOfBucket; i++ {
+			if b.entries[i] != nil {
+				e := (*entryOf[K, V])(b.entries[i])
+				hash := hasher(e.key, destTable.seed)
+				bidx := uint64(len(destTable.buckets)-1) & h1(hash)
+				destb := &destTable.buckets[bidx]
+				appendToBucketOf(h2(hash), b.entries[i], destb)
+				copied++
+			}
+		}
+		if b.next == nil {
+			rootb.mu.Unlock()
+			return
+		}
+		b = (*bucketOfPadded)(b.next)
+	}
+}
+
+// Range calls f sequentially for each key and value present in the
+// map. If f returns false, range stops the iteration.
+//
+// Range does not necessarily correspond to any consistent snapshot
+// of the Map's contents: no key will be visited more than once, but
+// if the value for any key is stored or deleted concurrently, Range
+// may reflect any mapping for that key from any point during the
+// Range call.
+//
+// It is safe to modify the map while iterating it, including entry
+// creation, modification and deletion. However, the concurrent
+// modification rule apply, i.e. the changes may be not reflected
+// in the subsequently iterated entries.
+func (m *MapOf[K, V]) Range(f func(key K, value V) bool) {
+	var zeroPtr unsafe.Pointer
+	// Pre-allocate array big enough to fit entries for most hash tables.
+	bentries := make([]unsafe.Pointer, 0, 16*entriesPerMapOfBucket)
+	tablep := atomic.LoadPointer(&m.table)
+	table := *(*mapOfTable[K, V])(tablep)
+	for i := range table.buckets {
+		rootb := &table.buckets[i]
+		b := rootb
+		// Prevent concurrent modifications and copy all entries into
+		// the intermediate slice.
+		rootb.mu.Lock()
+		for {
+			for i := 0; i < entriesPerMapOfBucket; i++ {
+				if b.entries[i] != nil {
+					bentries = append(bentries, b.entries[i])
+				}
+			}
+			if b.next == nil {
+				rootb.mu.Unlock()
+				break
+			}
+			b = (*bucketOfPadded)(b.next)
+		}
+		// Call the function for all copied entries.
+		for j := range bentries {
+			entry := (*entryOf[K, V])(bentries[j])
+			if !f(entry.key, entry.value) {
+				return
+			}
+			// Remove the reference to avoid preventing the copied
+			// entries from being GCed until this method finishes.
+			bentries[j] = zeroPtr
+		}
+		bentries = bentries[:0]
+	}
+}
+
+// Clear deletes all keys and values currently stored in the map.
+func (m *MapOf[K, V]) Clear() {
+	table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+	m.resize(table, mapClearHint)
+}
+
+// Size returns current size of the map.
+func (m *MapOf[K, V]) Size() int {
+	table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+	return int(table.sumSize())
+}
+
+func appendToBucketOf(h2 uint8, entryPtr unsafe.Pointer, b *bucketOfPadded) {
+	for {
+		for i := 0; i < entriesPerMapOfBucket; i++ {
+			if b.entries[i] == nil {
+				b.meta = setByte(b.meta, h2, i)
+				b.entries[i] = entryPtr
+				return
+			}
+		}
+		if b.next == nil {
+			newb := new(bucketOfPadded)
+			newb.meta = setByte(defaultMeta, h2, 0)
+			newb.entries[0] = entryPtr
+			b.next = unsafe.Pointer(newb)
+			return
+		}
+		b = (*bucketOfPadded)(b.next)
+	}
+}
+
+func (table *mapOfTable[K, V]) addSize(bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
+	atomic.AddInt64(&table.size[cidx].c, int64(delta))
+}
+
+func (table *mapOfTable[K, V]) addSizePlain(bucketIdx uint64, delta int) {
+	cidx := uint64(len(table.size)-1) & bucketIdx
+	table.size[cidx].c += int64(delta)
+}
+
+func (table *mapOfTable[K, V]) sumSize() int64 {
+	sum := int64(0)
+	for i := range table.size {
+		sum += atomic.LoadInt64(&table.size[i].c)
+	}
+	return sum
+}
+
+func h1(h uint64) uint64 {
+	return h >> 7
+}
+
+func h2(h uint64) uint8 {
+	return uint8(h & 0x7f)
+}
+
+// Stats returns statistics for the MapOf. Just like other map
+// methods, this one is thread-safe. Yet it's an O(N) operation,
+// so it should be used only for diagnostics or debugging purposes.
+func (m *MapOf[K, V]) Stats() MapStats {
+	stats := MapStats{
+		TotalGrowths: atomic.LoadInt64(&m.totalGrowths),
+		TotalShrinks: atomic.LoadInt64(&m.totalShrinks),
+		MinEntries:   math.MaxInt32,
+	}
+	table := (*mapOfTable[K, V])(atomic.LoadPointer(&m.table))
+	stats.RootBuckets = len(table.buckets)
+	stats.Counter = int(table.sumSize())
+	stats.CounterLen = len(table.size)
+	for i := range table.buckets {
+		nentries := 0
+		b := &table.buckets[i]
+		stats.TotalBuckets++
+		for {
+			nentriesLocal := 0
+			stats.Capacity += entriesPerMapOfBucket
+			for i := 0; i < entriesPerMapOfBucket; i++ {
+				if atomic.LoadPointer(&b.entries[i]) != nil {
+					stats.Size++
+					nentriesLocal++
+				}
+			}
+			nentries += nentriesLocal
+			if nentriesLocal == 0 {
+				stats.EmptyBuckets++
+			}
+			if b.next == nil {
+				break
+			}
+			b = (*bucketOfPadded)(atomic.LoadPointer(&b.next))
+			stats.TotalBuckets++
+		}
+		if nentries < stats.MinEntries {
+			stats.MinEntries = nentries
+		}
+		if nentries > stats.MaxEntries {
+			stats.MaxEntries = nentries
+		}
+	}
+	return stats
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/mpmcqueue.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/mpmcqueue.go
@@ -1,0 +1,125 @@
+package xsync
+
+import (
+	"runtime"
+	"sync/atomic"
+	"unsafe"
+)
+
+// A MPMCQueue is a bounded multi-producer multi-consumer concurrent
+// queue.
+//
+// MPMCQueue instances must be created with NewMPMCQueue function.
+// A MPMCQueue must not be copied after first use.
+//
+// Based on the data structure from the following C++ library:
+// https://github.com/rigtorp/MPMCQueue
+type MPMCQueue struct {
+	cap  uint64
+	head uint64
+	//lint:ignore U1000 prevents false sharing
+	hpad [cacheLineSize - 8]byte
+	tail uint64
+	//lint:ignore U1000 prevents false sharing
+	tpad  [cacheLineSize - 8]byte
+	slots []slotPadded
+}
+
+type slotPadded struct {
+	slot
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - unsafe.Sizeof(slot{})]byte
+}
+
+type slot struct {
+	turn uint64
+	item interface{}
+}
+
+// NewMPMCQueue creates a new MPMCQueue instance with the given
+// capacity.
+func NewMPMCQueue(capacity int) *MPMCQueue {
+	if capacity < 1 {
+		panic("capacity must be positive number")
+	}
+	return &MPMCQueue{
+		cap:   uint64(capacity),
+		slots: make([]slotPadded, capacity),
+	}
+}
+
+// Enqueue inserts the given item into the queue.
+// Blocks, if the queue is full.
+//
+// Deprecated: use TryEnqueue in combination with runtime.Gosched().
+func (q *MPMCQueue) Enqueue(item interface{}) {
+	head := atomic.AddUint64(&q.head, 1) - 1
+	slot := &q.slots[q.idx(head)]
+	turn := q.turn(head) * 2
+	for atomic.LoadUint64(&slot.turn) != turn {
+		runtime.Gosched()
+	}
+	slot.item = item
+	atomic.StoreUint64(&slot.turn, turn+1)
+}
+
+// Dequeue retrieves and removes the item from the head of the queue.
+// Blocks, if the queue is empty.
+//
+// Deprecated: use TryDequeue in combination with runtime.Gosched().
+func (q *MPMCQueue) Dequeue() interface{} {
+	tail := atomic.AddUint64(&q.tail, 1) - 1
+	slot := &q.slots[q.idx(tail)]
+	turn := q.turn(tail)*2 + 1
+	for atomic.LoadUint64(&slot.turn) != turn {
+		runtime.Gosched()
+	}
+	item := slot.item
+	slot.item = nil
+	atomic.StoreUint64(&slot.turn, turn+1)
+	return item
+}
+
+// TryEnqueue inserts the given item into the queue. Does not block
+// and returns immediately. The result indicates that the queue isn't
+// full and the item was inserted.
+func (q *MPMCQueue) TryEnqueue(item interface{}) bool {
+	head := atomic.LoadUint64(&q.head)
+	slot := &q.slots[q.idx(head)]
+	turn := q.turn(head) * 2
+	if atomic.LoadUint64(&slot.turn) == turn {
+		if atomic.CompareAndSwapUint64(&q.head, head, head+1) {
+			slot.item = item
+			atomic.StoreUint64(&slot.turn, turn+1)
+			return true
+		}
+	}
+	return false
+}
+
+// TryDequeue retrieves and removes the item from the head of the
+// queue. Does not block and returns immediately. The ok result
+// indicates that the queue isn't empty and an item was retrieved.
+func (q *MPMCQueue) TryDequeue() (item interface{}, ok bool) {
+	tail := atomic.LoadUint64(&q.tail)
+	slot := &q.slots[q.idx(tail)]
+	turn := q.turn(tail)*2 + 1
+	if atomic.LoadUint64(&slot.turn) == turn {
+		if atomic.CompareAndSwapUint64(&q.tail, tail, tail+1) {
+			item = slot.item
+			ok = true
+			slot.item = nil
+			atomic.StoreUint64(&slot.turn, turn+1)
+			return
+		}
+	}
+	return
+}
+
+func (q *MPMCQueue) idx(i uint64) uint64 {
+	return i % q.cap
+}
+
+func (q *MPMCQueue) turn(i uint64) uint64 {
+	return i / q.cap
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/mpmcqueueof.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/mpmcqueueof.go
@@ -1,0 +1,138 @@
+//go:build go1.19
+// +build go1.19
+
+package xsync
+
+import (
+	"runtime"
+	"sync/atomic"
+	"unsafe"
+)
+
+// A MPMCQueueOf is a bounded multi-producer multi-consumer concurrent
+// queue. It's a generic version of MPMCQueue.
+//
+// MPMCQueueOf instances must be created with NewMPMCQueueOf function.
+// A MPMCQueueOf must not be copied after first use.
+//
+// Based on the data structure from the following C++ library:
+// https://github.com/rigtorp/MPMCQueue
+type MPMCQueueOf[I any] struct {
+	cap  uint64
+	head uint64
+	//lint:ignore U1000 prevents false sharing
+	hpad [cacheLineSize - 8]byte
+	tail uint64
+	//lint:ignore U1000 prevents false sharing
+	tpad  [cacheLineSize - 8]byte
+	slots []slotOfPadded[I]
+}
+
+type slotOfPadded[I any] struct {
+	slotOf[I]
+	// Unfortunately, proper padding like the below one:
+	//
+	// pad [cacheLineSize - (unsafe.Sizeof(slotOf[I]{}) % cacheLineSize)]byte
+	//
+	// won't compile, so here we add a best-effort padding for items up to
+	// 56 bytes size.
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - unsafe.Sizeof(atomic.Uint64{})]byte
+}
+
+type slotOf[I any] struct {
+	// atomic.Uint64 is used here to get proper 8 byte alignment on
+	// 32-bit archs.
+	turn atomic.Uint64
+	item I
+}
+
+// NewMPMCQueueOf creates a new MPMCQueueOf instance with the given
+// capacity.
+func NewMPMCQueueOf[I any](capacity int) *MPMCQueueOf[I] {
+	if capacity < 1 {
+		panic("capacity must be positive number")
+	}
+	return &MPMCQueueOf[I]{
+		cap:   uint64(capacity),
+		slots: make([]slotOfPadded[I], capacity),
+	}
+}
+
+// Enqueue inserts the given item into the queue.
+// Blocks, if the queue is full.
+//
+// Deprecated: use TryEnqueue in combination with runtime.Gosched().
+func (q *MPMCQueueOf[I]) Enqueue(item I) {
+	head := atomic.AddUint64(&q.head, 1) - 1
+	slot := &q.slots[q.idx(head)]
+	turn := q.turn(head) * 2
+	for slot.turn.Load() != turn {
+		runtime.Gosched()
+	}
+	slot.item = item
+	slot.turn.Store(turn + 1)
+}
+
+// Dequeue retrieves and removes the item from the head of the queue.
+// Blocks, if the queue is empty.
+//
+// Deprecated: use TryDequeue in combination with runtime.Gosched().
+func (q *MPMCQueueOf[I]) Dequeue() I {
+	var zeroI I
+	tail := atomic.AddUint64(&q.tail, 1) - 1
+	slot := &q.slots[q.idx(tail)]
+	turn := q.turn(tail)*2 + 1
+	for slot.turn.Load() != turn {
+		runtime.Gosched()
+	}
+	item := slot.item
+	slot.item = zeroI
+	slot.turn.Store(turn + 1)
+	return item
+}
+
+// TryEnqueue inserts the given item into the queue. Does not block
+// and returns immediately. The result indicates that the queue isn't
+// full and the item was inserted.
+func (q *MPMCQueueOf[I]) TryEnqueue(item I) bool {
+	head := atomic.LoadUint64(&q.head)
+	slot := &q.slots[q.idx(head)]
+	turn := q.turn(head) * 2
+	if slot.turn.Load() == turn {
+		if atomic.CompareAndSwapUint64(&q.head, head, head+1) {
+			slot.item = item
+			slot.turn.Store(turn + 1)
+			return true
+		}
+	}
+	return false
+}
+
+// TryDequeue retrieves and removes the item from the head of the
+// queue. Does not block and returns immediately. The ok result
+// indicates that the queue isn't empty and an item was retrieved.
+func (q *MPMCQueueOf[I]) TryDequeue() (item I, ok bool) {
+	tail := atomic.LoadUint64(&q.tail)
+	slot := &q.slots[q.idx(tail)]
+	turn := q.turn(tail)*2 + 1
+	if slot.turn.Load() == turn {
+		if atomic.CompareAndSwapUint64(&q.tail, tail, tail+1) {
+			var zeroI I
+			item = slot.item
+			ok = true
+			slot.item = zeroI
+			slot.turn.Store(turn + 1)
+			return
+		}
+	}
+	return
+}
+
+func (q *MPMCQueueOf[I]) idx(i uint64) uint64 {
+	return i % q.cap
+}
+
+func (q *MPMCQueueOf[I]) turn(i uint64) uint64 {
+	return i / q.cap
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/rbmutex.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/rbmutex.go
@@ -1,0 +1,188 @@
+package xsync
+
+import (
+	"runtime"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// slow-down guard
+const nslowdown = 7
+
+// pool for reader tokens
+var rtokenPool sync.Pool
+
+// RToken is a reader lock token.
+type RToken struct {
+	slot uint32
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 4]byte
+}
+
+// A RBMutex is a reader biased reader/writer mutual exclusion lock.
+// The lock can be held by an many readers or a single writer.
+// The zero value for a RBMutex is an unlocked mutex.
+//
+// A RBMutex must not be copied after first use.
+//
+// RBMutex is based on a modified version of BRAVO
+// (Biased Locking for Reader-Writer Locks) algorithm:
+// https://arxiv.org/pdf/1810.01553.pdf
+//
+// RBMutex is a specialized mutex for scenarios, such as caches,
+// where the vast majority of locks are acquired by readers and write
+// lock acquire attempts are infrequent. In such scenarios, RBMutex
+// performs better than sync.RWMutex on large multicore machines.
+//
+// RBMutex extends sync.RWMutex internally and uses it as the "reader
+// bias disabled" fallback, so the same semantics apply. The only
+// noticeable difference is in reader tokens returned from the
+// RLock/RUnlock methods.
+type RBMutex struct {
+	rslots       []rslot
+	rmask        uint32
+	rbias        int32
+	inhibitUntil time.Time
+	rw           sync.RWMutex
+}
+
+type rslot struct {
+	mu int32
+	//lint:ignore U1000 prevents false sharing
+	pad [cacheLineSize - 4]byte
+}
+
+// NewRBMutex creates a new RBMutex instance.
+func NewRBMutex() *RBMutex {
+	nslots := nextPowOf2(parallelism())
+	mu := RBMutex{
+		rslots: make([]rslot, nslots),
+		rmask:  nslots - 1,
+		rbias:  1,
+	}
+	return &mu
+}
+
+// TryRLock tries to lock m for reading without blocking.
+// When TryRLock succeeds, it returns true and a reader token.
+// In case of a failure, a false is returned.
+func (mu *RBMutex) TryRLock() (bool, *RToken) {
+	if t := mu.fastRlock(); t != nil {
+		return true, t
+	}
+	// Optimistic slow path.
+	if mu.rw.TryRLock() {
+		if atomic.LoadInt32(&mu.rbias) == 0 && time.Now().After(mu.inhibitUntil) {
+			atomic.StoreInt32(&mu.rbias, 1)
+		}
+		return true, nil
+	}
+	return false, nil
+}
+
+// RLock locks m for reading and returns a reader token. The
+// token must be used in the later RUnlock call.
+//
+// Should not be used for recursive read locking; a blocked Lock
+// call excludes new readers from acquiring the lock.
+func (mu *RBMutex) RLock() *RToken {
+	if t := mu.fastRlock(); t != nil {
+		return t
+	}
+	// Slow path.
+	mu.rw.RLock()
+	if atomic.LoadInt32(&mu.rbias) == 0 && time.Now().After(mu.inhibitUntil) {
+		atomic.StoreInt32(&mu.rbias, 1)
+	}
+	return nil
+}
+
+func (mu *RBMutex) fastRlock() *RToken {
+	if atomic.LoadInt32(&mu.rbias) == 1 {
+		t, ok := rtokenPool.Get().(*RToken)
+		if !ok {
+			t = new(RToken)
+			t.slot = runtime_fastrand()
+		}
+		// Try all available slots to distribute reader threads to slots.
+		for i := 0; i < len(mu.rslots); i++ {
+			slot := t.slot + uint32(i)
+			rslot := &mu.rslots[slot&mu.rmask]
+			rslotmu := atomic.LoadInt32(&rslot.mu)
+			if atomic.CompareAndSwapInt32(&rslot.mu, rslotmu, rslotmu+1) {
+				if atomic.LoadInt32(&mu.rbias) == 1 {
+					// Hot path succeeded.
+					t.slot = slot
+					return t
+				}
+				// The mutex is no longer reader biased. Roll back.
+				atomic.AddInt32(&rslot.mu, -1)
+				rtokenPool.Put(t)
+				return nil
+			}
+			// Contention detected. Give a try with the next slot.
+		}
+	}
+	return nil
+}
+
+// RUnlock undoes a single RLock call. A reader token obtained from
+// the RLock call must be provided. RUnlock does not affect other
+// simultaneous readers. A panic is raised if m is not locked for
+// reading on entry to RUnlock.
+func (mu *RBMutex) RUnlock(t *RToken) {
+	if t == nil {
+		mu.rw.RUnlock()
+		return
+	}
+	if atomic.AddInt32(&mu.rslots[t.slot&mu.rmask].mu, -1) < 0 {
+		panic("invalid reader state detected")
+	}
+	rtokenPool.Put(t)
+}
+
+// TryLock tries to lock m for writing without blocking.
+func (mu *RBMutex) TryLock() bool {
+	if mu.rw.TryLock() {
+		if atomic.LoadInt32(&mu.rbias) == 1 {
+			atomic.StoreInt32(&mu.rbias, 0)
+			for i := 0; i < len(mu.rslots); i++ {
+				if atomic.LoadInt32(&mu.rslots[i].mu) > 0 {
+					// There is a reader. Roll back.
+					atomic.StoreInt32(&mu.rbias, 1)
+					mu.rw.Unlock()
+					return false
+				}
+			}
+		}
+		return true
+	}
+	return false
+}
+
+// Lock locks m for writing. If the lock is already locked for
+// reading or writing, Lock blocks until the lock is available.
+func (mu *RBMutex) Lock() {
+	mu.rw.Lock()
+	if atomic.LoadInt32(&mu.rbias) == 1 {
+		atomic.StoreInt32(&mu.rbias, 0)
+		start := time.Now()
+		for i := 0; i < len(mu.rslots); i++ {
+			for atomic.LoadInt32(&mu.rslots[i].mu) > 0 {
+				runtime.Gosched()
+			}
+		}
+		mu.inhibitUntil = time.Now().Add(time.Since(start) * nslowdown)
+	}
+}
+
+// Unlock unlocks m for writing. A panic is raised if m is not locked
+// for writing on entry to Unlock.
+//
+// As with RWMutex, a locked RBMutex is not associated with a
+// particular goroutine. One goroutine may RLock (Lock) a RBMutex and
+// then arrange for another goroutine to RUnlock (Unlock) it.
+func (mu *RBMutex) Unlock() {
+	mu.rw.Unlock()
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/spscqueue.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/spscqueue.go
@@ -1,0 +1,92 @@
+package xsync
+
+import (
+	"sync/atomic"
+)
+
+// A SPSCQueue is a bounded single-producer single-consumer concurrent
+// queue. This means that not more than a single goroutine must be
+// publishing items to the queue while not more than a single goroutine
+// must be consuming those items.
+//
+// SPSCQueue instances must be created with NewSPSCQueue function.
+// A SPSCQueue must not be copied after first use.
+//
+// Based on the data structure from the following article:
+// https://rigtorp.se/ringbuffer/
+type SPSCQueue struct {
+	cap  uint64
+	pidx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad0       [cacheLineSize - 8]byte
+	pcachedIdx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad1 [cacheLineSize - 8]byte
+	cidx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad2       [cacheLineSize - 8]byte
+	ccachedIdx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad3  [cacheLineSize - 8]byte
+	items []interface{}
+}
+
+// NewSPSCQueue creates a new SPSCQueue instance with the given
+// capacity.
+func NewSPSCQueue(capacity int) *SPSCQueue {
+	if capacity < 1 {
+		panic("capacity must be positive number")
+	}
+	return &SPSCQueue{
+		cap:   uint64(capacity + 1),
+		items: make([]interface{}, capacity+1),
+	}
+}
+
+// TryEnqueue inserts the given item into the queue. Does not block
+// and returns immediately. The result indicates that the queue isn't
+// full and the item was inserted.
+func (q *SPSCQueue) TryEnqueue(item interface{}) bool {
+	// relaxed memory order would be enough here
+	idx := atomic.LoadUint64(&q.pidx)
+	nextIdx := idx + 1
+	if nextIdx == q.cap {
+		nextIdx = 0
+	}
+	cachedIdx := q.ccachedIdx
+	if nextIdx == cachedIdx {
+		cachedIdx = atomic.LoadUint64(&q.cidx)
+		q.ccachedIdx = cachedIdx
+		if nextIdx == cachedIdx {
+			return false
+		}
+	}
+	q.items[idx] = item
+	atomic.StoreUint64(&q.pidx, nextIdx)
+	return true
+}
+
+// TryDequeue retrieves and removes the item from the head of the
+// queue. Does not block and returns immediately. The ok result
+// indicates that the queue isn't empty and an item was retrieved.
+func (q *SPSCQueue) TryDequeue() (item interface{}, ok bool) {
+	// relaxed memory order would be enough here
+	idx := atomic.LoadUint64(&q.cidx)
+	cachedIdx := q.pcachedIdx
+	if idx == cachedIdx {
+		cachedIdx = atomic.LoadUint64(&q.pidx)
+		q.pcachedIdx = cachedIdx
+		if idx == cachedIdx {
+			return
+		}
+	}
+	item = q.items[idx]
+	q.items[idx] = nil
+	ok = true
+	nextIdx := idx + 1
+	if nextIdx == q.cap {
+		nextIdx = 0
+	}
+	atomic.StoreUint64(&q.cidx, nextIdx)
+	return
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/spscqueueof.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/spscqueueof.go
@@ -1,0 +1,96 @@
+//go:build go1.19
+// +build go1.19
+
+package xsync
+
+import (
+	"sync/atomic"
+)
+
+// A SPSCQueueOf is a bounded single-producer single-consumer concurrent
+// queue. This means that not more than a single goroutine must be
+// publishing items to the queue while not more than a single goroutine
+// must be consuming those items.
+//
+// SPSCQueueOf instances must be created with NewSPSCQueueOf function.
+// A SPSCQueueOf must not be copied after first use.
+//
+// Based on the data structure from the following article:
+// https://rigtorp.se/ringbuffer/
+type SPSCQueueOf[I any] struct {
+	cap  uint64
+	pidx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad0       [cacheLineSize - 8]byte
+	pcachedIdx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad1 [cacheLineSize - 8]byte
+	cidx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad2       [cacheLineSize - 8]byte
+	ccachedIdx uint64
+	//lint:ignore U1000 prevents false sharing
+	pad3  [cacheLineSize - 8]byte
+	items []I
+}
+
+// NewSPSCQueueOf creates a new SPSCQueueOf instance with the given
+// capacity.
+func NewSPSCQueueOf[I any](capacity int) *SPSCQueueOf[I] {
+	if capacity < 1 {
+		panic("capacity must be positive number")
+	}
+	return &SPSCQueueOf[I]{
+		cap:   uint64(capacity + 1),
+		items: make([]I, capacity+1),
+	}
+}
+
+// TryEnqueue inserts the given item into the queue. Does not block
+// and returns immediately. The result indicates that the queue isn't
+// full and the item was inserted.
+func (q *SPSCQueueOf[I]) TryEnqueue(item I) bool {
+	// relaxed memory order would be enough here
+	idx := atomic.LoadUint64(&q.pidx)
+	next_idx := idx + 1
+	if next_idx == q.cap {
+		next_idx = 0
+	}
+	cached_idx := q.ccachedIdx
+	if next_idx == cached_idx {
+		cached_idx = atomic.LoadUint64(&q.cidx)
+		q.ccachedIdx = cached_idx
+		if next_idx == cached_idx {
+			return false
+		}
+	}
+	q.items[idx] = item
+	atomic.StoreUint64(&q.pidx, next_idx)
+	return true
+}
+
+// TryDequeue retrieves and removes the item from the head of the
+// queue. Does not block and returns immediately. The ok result
+// indicates that the queue isn't empty and an item was retrieved.
+func (q *SPSCQueueOf[I]) TryDequeue() (item I, ok bool) {
+	// relaxed memory order would be enough here
+	idx := atomic.LoadUint64(&q.cidx)
+	cached_idx := q.pcachedIdx
+	if idx == cached_idx {
+		cached_idx = atomic.LoadUint64(&q.pidx)
+		q.pcachedIdx = cached_idx
+		if idx == cached_idx {
+			return
+		}
+	}
+	var zeroI I
+	item = q.items[idx]
+	q.items[idx] = zeroI
+	ok = true
+	next_idx := idx + 1
+	if next_idx == q.cap {
+		next_idx = 0
+	}
+	atomic.StoreUint64(&q.cidx, next_idx)
+	return
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/util.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/util.go
@@ -1,0 +1,66 @@
+package xsync
+
+import (
+	"math/bits"
+	"runtime"
+	_ "unsafe"
+)
+
+// test-only assert()-like flag
+var assertionsEnabled = false
+
+const (
+	// cacheLineSize is used in paddings to prevent false sharing;
+	// 64B are used instead of 128B as a compromise between
+	// memory footprint and performance; 128B usage may give ~30%
+	// improvement on NUMA machines.
+	cacheLineSize = 64
+)
+
+// nextPowOf2 computes the next highest power of 2 of 32-bit v.
+// Source: https://graphics.stanford.edu/~seander/bithacks.html#RoundUpPowerOf2
+func nextPowOf2(v uint32) uint32 {
+	if v == 0 {
+		return 1
+	}
+	v--
+	v |= v >> 1
+	v |= v >> 2
+	v |= v >> 4
+	v |= v >> 8
+	v |= v >> 16
+	v++
+	return v
+}
+
+func parallelism() uint32 {
+	maxProcs := uint32(runtime.GOMAXPROCS(0))
+	numCores := uint32(runtime.NumCPU())
+	if maxProcs < numCores {
+		return maxProcs
+	}
+	return numCores
+}
+
+//go:noescape
+//go:linkname runtime_fastrand runtime.fastrand
+func runtime_fastrand() uint32
+
+func broadcast(b uint8) uint64 {
+	return 0x101010101010101 * uint64(b)
+}
+
+func firstMarkedByteIndex(w uint64) int {
+	return bits.TrailingZeros64(w) >> 3
+}
+
+// SWAR byte search: may produce false positives, e.g. for 0x0100,
+// so make sure to double-check bytes found by this function.
+func markZeroBytes(w uint64) uint64 {
+	return ((w - 0x0101010101010101) & (^w) & 0x8080808080808080)
+}
+
+func setByte(w uint64, b uint8, idx int) uint64 {
+	shift := idx << 3
+	return (w &^ (0xff << shift)) | (uint64(b) << shift)
+}

--- a/vendor/github.com/puzpuzpuz/xsync/v3/util_hash.go
+++ b/vendor/github.com/puzpuzpuz/xsync/v3/util_hash.go
@@ -1,0 +1,77 @@
+package xsync
+
+import (
+	"reflect"
+	"unsafe"
+)
+
+// makeSeed creates a random seed.
+func makeSeed() uint64 {
+	var s1 uint32
+	for {
+		s1 = runtime_fastrand()
+		// We use seed 0 to indicate an uninitialized seed/hash,
+		// so keep trying until we get a non-zero seed.
+		if s1 != 0 {
+			break
+		}
+	}
+	s2 := runtime_fastrand()
+	return uint64(s1)<<32 | uint64(s2)
+}
+
+// hashString calculates a hash of s with the given seed.
+func hashString(s string, seed uint64) uint64 {
+	if s == "" {
+		return seed
+	}
+	strh := (*reflect.StringHeader)(unsafe.Pointer(&s))
+	return uint64(runtime_memhash(unsafe.Pointer(strh.Data), uintptr(seed), uintptr(strh.Len)))
+}
+
+//go:noescape
+//go:linkname runtime_memhash runtime.memhash
+func runtime_memhash(p unsafe.Pointer, h, s uintptr) uintptr
+
+// defaultHasher creates a fast hash function for the given comparable type.
+// The only limitation is that the type should not contain interfaces inside
+// based on runtime.typehash.
+func defaultHasher[T comparable]() func(T, uint64) uint64 {
+	var zero T
+
+	if reflect.TypeOf(&zero).Elem().Kind() == reflect.Interface {
+		return func(value T, seed uint64) uint64 {
+			iValue := any(value)
+			i := (*iface)(unsafe.Pointer(&iValue))
+			return runtime_typehash64(i.typ, i.word, seed)
+		}
+	} else {
+		var iZero any = zero
+		i := (*iface)(unsafe.Pointer(&iZero))
+		return func(value T, seed uint64) uint64 {
+			return runtime_typehash64(i.typ, unsafe.Pointer(&value), seed)
+		}
+	}
+}
+
+// how interface is represented in memory
+type iface struct {
+	typ  uintptr
+	word unsafe.Pointer
+}
+
+// same as runtime_typehash, but always returns a uint64
+// see: maphash.rthash function for details
+func runtime_typehash64(t uintptr, p unsafe.Pointer, seed uint64) uint64 {
+	if unsafe.Sizeof(uintptr(0)) == 8 {
+		return uint64(runtime_typehash(t, p, uintptr(seed)))
+	}
+
+	lo := runtime_typehash(t, p, uintptr(seed))
+	hi := runtime_typehash(t, p, uintptr(seed>>32))
+	return uint64(hi)<<32 | uint64(lo)
+}
+
+//go:noescape
+//go:linkname runtime_typehash runtime.typehash
+func runtime_typehash(t uintptr, p unsafe.Pointer, h uintptr) uintptr

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright 2009 The Go Authors.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google LLC nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/errgroup/errgroup.go
+++ b/vendor/golang.org/x/sync/errgroup/errgroup.go
@@ -1,0 +1,136 @@
+// Copyright 2016 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package errgroup provides synchronization, error propagation, and Context
+// cancelation for groups of goroutines working on subtasks of a common task.
+//
+// [errgroup.Group] is related to [sync.WaitGroup] but adds handling of tasks
+// returning errors.
+package errgroup
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+type token struct{}
+
+// A Group is a collection of goroutines working on subtasks that are part of
+// the same overall task.
+//
+// A zero Group is valid, has no limit on the number of active goroutines,
+// and does not cancel on error.
+type Group struct {
+	cancel func(error)
+
+	wg sync.WaitGroup
+
+	sem chan token
+
+	errOnce sync.Once
+	err     error
+}
+
+func (g *Group) done() {
+	if g.sem != nil {
+		<-g.sem
+	}
+	g.wg.Done()
+}
+
+// WithContext returns a new Group and an associated Context derived from ctx.
+//
+// The derived Context is canceled the first time a function passed to Go
+// returns a non-nil error or the first time Wait returns, whichever occurs
+// first.
+func WithContext(ctx context.Context) (*Group, context.Context) {
+	ctx, cancel := context.WithCancelCause(ctx)
+	return &Group{cancel: cancel}, ctx
+}
+
+// Wait blocks until all function calls from the Go method have returned, then
+// returns the first non-nil error (if any) from them.
+func (g *Group) Wait() error {
+	g.wg.Wait()
+	if g.cancel != nil {
+		g.cancel(g.err)
+	}
+	return g.err
+}
+
+// Go calls the given function in a new goroutine.
+// It blocks until the new goroutine can be added without the number of
+// active goroutines in the group exceeding the configured limit.
+//
+// The first call to return a non-nil error cancels the group's context, if the
+// group was created by calling WithContext. The error will be returned by Wait.
+func (g *Group) Go(f func() error) {
+	if g.sem != nil {
+		g.sem <- token{}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+}
+
+// TryGo calls the given function in a new goroutine only if the number of
+// active goroutines in the group is currently below the configured limit.
+//
+// The return value reports whether the goroutine was started.
+func (g *Group) TryGo(f func() error) bool {
+	if g.sem != nil {
+		select {
+		case g.sem <- token{}:
+			// Note: this allows barging iff channels in general allow barging.
+		default:
+			return false
+		}
+	}
+
+	g.wg.Add(1)
+	go func() {
+		defer g.done()
+
+		if err := f(); err != nil {
+			g.errOnce.Do(func() {
+				g.err = err
+				if g.cancel != nil {
+					g.cancel(g.err)
+				}
+			})
+		}
+	}()
+	return true
+}
+
+// SetLimit limits the number of active goroutines in this group to at most n.
+// A negative value indicates no limit.
+// A limit of zero will prevent any new goroutines from being added.
+//
+// Any subsequent call to the Go method will block until it can add an active
+// goroutine without exceeding the configured limit.
+//
+// The limit must not be modified while any goroutines in the group are active.
+func (g *Group) SetLimit(n int) {
+	if n < 0 {
+		g.sem = nil
+		return
+	}
+	if len(g.sem) != 0 {
+		panic(fmt.Errorf("errgroup: modify limit while %v goroutines in the group are still active", len(g.sem)))
+	}
+	g.sem = make(chan token, n)
+}


### PR DESCRIPTION
Only emit prometheus metrics for processes alive
for X minutes - this will reduce cardinality by not
emitting metrics for very short lived processes.