### PR TITLE
Reduce client/server unresolved IP cardinality

### DIFF
--- a/pkg/export/prom/prom.go
+++ b/pkg/export/prom/prom.go
@@ -970,17 +970,17 @@ func labelNamesServiceGraph() []string {
 func (r *metricsReporter) labelValuesServiceGraph(span *request.Span) []string {
 	if span.IsClientSpan() {
 		return []string{
-			request.SpanPeer(span),
+			request.SpanPeerName(span),
 			span.Service.UID.Namespace,
-			request.SpanHost(span),
+			request.SpanHostName(span),
 			span.OtherNamespace,
 			"beyla",
 		}
 	}
 	return []string{
-		request.SpanPeer(span),
+		request.SpanPeerName(span),
 		span.OtherNamespace,
-		request.SpanHost(span),
+		request.SpanHostName(span),
 		span.Service.UID.Namespace,
 		"beyla",
 	}

--- a/pkg/flaggy/flag.go
+++ b/pkg/flaggy/flag.go
@@ -3,6 +3,7 @@ package flaggy
 import (
 	"flag"
 	"os"
+	"strconv"
 	"time"
 )
 
@@ -21,4 +22,21 @@ func GetEnvDurationVar(
 	}
 
 	return flag.Duration(flagName, defaultVal, description)
+}
+
+func GetEnvBoolVar(
+	envVarName string,
+	flagName string,
+	description string,
+	defaultVal bool,
+) *bool {
+	envVal := os.Getenv(envVarName)
+	if len(envVal) > 0 {
+		boolVal, err := strconv.ParseBool(envVal)
+		if err == nil {
+			return &boolVal
+		}
+	}
+
+	return flag.Bool(flagName, defaultVal, description)
 }

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -1,6 +1,7 @@
 package request
 
 import (
+	"net"
 	"strings"
 	"unicode/utf8"
 
@@ -118,7 +119,7 @@ func SpanHost(span *Span) string {
 	return span.Host
 }
 
-// SpanPeerName returns the host name from the span. If the host name is not set, it returns "Unresolved Host".
+// SpanPeerName returns the host name from the span, or "Unresolved Host".
 // This is used instead of SpanHost in metrics to avoid high cardinality of external IPs which are
 // not DNS resolvable.
 func SpanHostName(span *Span) string {
@@ -126,7 +127,16 @@ func SpanHostName(span *Span) string {
 		return span.HostName
 	}
 
-	return "Unresolved Host"
+	if span.Host != "" {
+		ip := net.ParseIP(span.Host)
+		if ip != nil {
+			return "Unresolved Host"
+		}
+
+		return span.Host
+	}
+
+	return ""
 }
 
 func SpanPeer(span *Span) string {
@@ -137,7 +147,7 @@ func SpanPeer(span *Span) string {
 	return span.Peer
 }
 
-// SpanPeerName returns the peer name from the span. If the peer name is not set, it returns "Unresolved IP".
+// SpanPeerName returns the peer name from the span, or "Unresolved IP".
 // This is used instead of SpanPeer in metrics to avoid high cardinality of external IPs which are
 // not DNS resolvable.
 func SpanPeerName(span *Span) string {
@@ -145,7 +155,16 @@ func SpanPeerName(span *Span) string {
 		return span.PeerName
 	}
 
-	return "Unresolved IP"
+	if span.Peer != "" {
+		ip := net.ParseIP(span.Peer)
+		if ip != nil {
+			return "Unresolved IP"
+		}
+
+		return span.Peer
+	}
+
+	return ""
 }
 
 func HTTPClientHost(span *Span) string {

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -8,6 +8,14 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 
 	attr "github.com/grafana/beyla/v2/pkg/export/attributes/names"
+	"github.com/grafana/beyla/v2/pkg/flaggy"
+)
+
+var metricsAllowUnresolvedIP = flaggy.GetEnvBoolVar(
+	"METRICS_ALLOW_UNRESOLVED_IP",
+	"metrics_allow_unresolved_ip",
+	"Allow unresolved IP in metrics",
+	false,
 )
 
 func HTTPRequestMethod(val string) attribute.KeyValue {
@@ -127,6 +135,10 @@ func SpanHostName(span *Span) string {
 		return span.HostName
 	}
 
+	if *metricsAllowUnresolvedIP {
+		return span.Host
+	}
+
 	if span.Host != "" {
 		ip := net.ParseIP(span.Host)
 		if ip != nil {
@@ -153,6 +165,10 @@ func SpanPeer(span *Span) string {
 func SpanPeerName(span *Span) string {
 	if span.PeerName != "" {
 		return span.PeerName
+	}
+
+	if *metricsAllowUnresolvedIP {
+		return span.Peer
 	}
 
 	if span.Peer != "" {

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -118,12 +118,34 @@ func SpanHost(span *Span) string {
 	return span.Host
 }
 
+// SpanPeerName returns the host name from the span. If the host name is not set, it returns "Unresolved Host".
+// This is used instead of SpanHost in metrics to avoid high cardinality of external IPs which are
+// not DNS resolvable.
+func SpanHostName(span *Span) string {
+	if span.HostName != "" {
+		return span.HostName
+	}
+
+	return "Unresolved Host"
+}
+
 func SpanPeer(span *Span) string {
 	if span.PeerName != "" {
 		return span.PeerName
 	}
 
 	return span.Peer
+}
+
+// SpanPeerName returns the peer name from the span. If the peer name is not set, it returns "Unresolved IP".
+// This is used instead of SpanPeer in metrics to avoid high cardinality of external IPs which are
+// not DNS resolvable.
+func SpanPeerName(span *Span) string {
+	if span.PeerName != "" {
+		return span.PeerName
+	}
+
+	return "Unresolved IP"
 }
 
 func HTTPClientHost(span *Span) string {

--- a/pkg/internal/request/metric_attributes.go
+++ b/pkg/internal/request/metric_attributes.go
@@ -127,7 +127,7 @@ func SpanHost(span *Span) string {
 	return span.Host
 }
 
-// SpanPeerName returns the host name from the span, or "Unresolved Host".
+// SpanHostName returns the host name from the span, or "Unresolved Host".
 // This is used instead of SpanHost in metrics to avoid high cardinality of external IPs which are
 // not DNS resolvable.
 func SpanHostName(span *Span) string {

--- a/pkg/internal/request/span_getters.go
+++ b/pkg/internal/request/span_getters.go
@@ -26,7 +26,7 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	var getter attributes.Getter[*Span, attribute.KeyValue]
 	switch name {
 	case attr.Client:
-		getter = func(s *Span) attribute.KeyValue { return ClientMetric(SpanPeer(s)) }
+		getter = func(s *Span) attribute.KeyValue { return ClientMetric(SpanPeerName(s)) }
 	case attr.ClientNamespace:
 		getter = func(s *Span) attribute.KeyValue {
 			if s.IsClientSpan() {
@@ -62,7 +62,7 @@ func SpanOTELGetters(name attr.Name) (attributes.Getter[*Span, attribute.KeyValu
 	case attr.RPCGRPCStatusCode:
 		getter = func(s *Span) attribute.KeyValue { return semconv.RPCGRPCStatusCodeKey.Int(s.Status) }
 	case attr.Server:
-		getter = func(s *Span) attribute.KeyValue { return ServerMetric(SpanHost(s)) }
+		getter = func(s *Span) attribute.KeyValue { return ServerMetric(SpanHostName(s)) }
 	case attr.ServerNamespace:
 		getter = func(s *Span) attribute.KeyValue {
 			if s.IsClientSpan() {


### PR DESCRIPTION
Reduce cardinality from unresolved IPs. In-cluster IPs and DNS resolved IPs are preserved, but unresolved IPs are translated to "Unresolved Host/IP" to reduce cardinality