### PR TITLE
Use k8s label for service name override

### DIFF
--- a/pkg/internal/kube/store.go
+++ b/pkg/internal/kube/store.go
@@ -61,8 +61,8 @@ const (
 var DefaultResourceLabels = ResourceLabels{
 	// If a user sets useLabelsForResourceAttributes: false in its OTEL operator config, is the task of the
 	// OTEL operator to provide empty values for this.
-	// Disabled k8s service.name based resolution as it leads to duplicate nodes
-	//"service.name":      []string{"app.kubernetes.io/name"},
+	"service.name": []string{"app.kubernetes.io/name"},
+	// Disabled k8s service.namespace based resolution as it leads to duplicate nodes
 	//"service.namespace": []string{"app.kubernetes.io/part-of"},
 	//"service.version":   []string{"app.kubernetes.io/version"},
 }


### PR DESCRIPTION
For k8s jobs which have `app.kubernetes.io/name` label, this change will help in using a static name instead of dynamic job name for service label